### PR TITLE
Chore : tailwind 설정 내 색상 키 이름 변경

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,6 +35,10 @@ const config: Config = {
         red: {
           light: "#FFEFEF",
         },
+        gray: {
+          default: "#969696",
+          dark: "#3F3F3F",
+        },
         bggray: {
           light: "#F1F1F1",
           dark: "#C2C2C2",
@@ -51,10 +55,6 @@ const config: Config = {
           20: "#CCCCCC",
           10: "#E6E6E6",
           5: "#F3F3F3",
-        },
-        text: {
-          "gray-default": "#969696",
-          "gray-dark": "#3F3F3F",
         },
       },
     },


### PR DESCRIPTION
- 변경사항 및 이유: 기존 설정 이름이 tailwind className과 중첩되어 속성 이름 변경
- 작업 내역: tailwind.config.ts 내 theme.colors 안의 속성 이름을 다음과 같이 변경

// 기존
```
text: {
  "gray-default": "#969696",
  "gray-dark": "#3F3F3F",
},
```

// 개선
```
gray: {
  default: "#969696",
  dark: "#3F3F3F",
},
```
