### PR TITLE
Feat : 공통 Label 컴포넌트 추가

### DIFF
--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+const labelVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-full tracking-[-0.01em] text-base",
+  {
+    variants: {
+      variant: {
+        // 취약점 DB
+        hot: "px-3 py-2 h-[2.188rem] bg-accent-red text-white font-semibold leading-[1.216rem]",
+        new: "px-3 py-2 h-[2.188rem] bg-accent-blue text-white font-semibold leading-[1.216rem]",
+        unselected:
+          "px-3 py-2 h-[2.188rem] bg-[#E8E8E8] text-[#ADADAD] font-semibold leading-[1.216rem]",
+
+        // MY 저장소 - UI 스크랩
+        clipping:
+          "px-3 py-2 h-[2.188rem] bg-bggray-light text-gray-default font-semibold leading-[1.216rem]",
+        "clipping-notify":
+          "px-3 py-2 h-[2.188rem] bg-primary-50 text-primary-500 font-semibold leading-[1.216rem]",
+        "clipping-warning":
+          "px-3 py-2 h-[2.188rem] bg-red-light text-accent-red font-semibold leading-[1.216rem]",
+
+        // MY 저장소 - 메인 (로그인 o)
+        outline:
+          "px-[0.75rem] py-[0.438rem] h-[1.875rem] bg-white font-normal border border-gray-dark leading-4",
+
+        // MY 저장소 - UI 검출된 파일
+        "outline-primary":
+          "px-[0.75rem] py-[0.438rem] h-[1.875rem] bg-purple-light text-primary-500 font-normal border border-primary-300 leading-4",
+      },
+    },
+    defaultVariants: {
+      variant: "hot",
+    },
+  },
+);
+
+export interface LabelProps
+  extends React.LabelHTMLAttributes<HTMLLabelElement>,
+    VariantProps<typeof labelVariants> {}
+
+const Label: React.FC<LabelProps> = ({
+  className,
+  variant,
+  children,
+  ...props
+}) => {
+  return (
+    <span className={cn(labelVariants({ variant, className }))} {...props}>
+      {children}
+    </span>
+  );
+};
+
+Label.displayName = "Label";
+
+export { Label };


### PR DESCRIPTION
## 변경사항 및 이유

- 회의 때 이야기 나누었던 것 처럼, Figma 상으로 Chips (Assist Chips, Suggestion Chips) 부분을 Label 컴포넌트로 만들었습니다.

## 작업 내역

- components > ui 폴더 하위에 Label 파일을 추가했습니다.
- Label의 variant로 ‘hot’, ‘new’, ‘unselected’, ‘clipping’, ‘clipping-notify’, ‘clipping-warning’, ‘outline’, ‘outline-primary’를 만들었습니다.
- Label의 defaultVariants는 'hot'으로 설정했습니다.

## PR 특이 사항

- 어떤 페이지에서 어떤 variant의 Label이 사용되는지는 피그마를 참고하여 하단 이미지에 첨부해두었습니다. 확인 부탁드립니다!

![label](https://github.com/user-attachments/assets/43c3f56f-492b-433f-8f7e-07af57a5df87)

![사용법](https://github.com/user-attachments/assets/75c9a03e-9ecc-4431-8355-dd2230b4e871)


