### PR TITLE
Feat : 공통 InputChip 컴포넌트 추가

### DIFF
--- a/src/components/ui/Icons.tsx
+++ b/src/components/ui/Icons.tsx
@@ -29,8 +29,8 @@ export function IconClose({
 }: React.ComponentProps<"svg">) {
   return (
     <svg
-      width="12"
-      height="12"
+      width="11.5"
+      height="11.5"
       viewBox="0 0 12 12"
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/ui/InputChip.tsx
+++ b/src/components/ui/InputChip.tsx
@@ -1,0 +1,45 @@
+import { IconClose, IconRoundedDoc } from "@/components/ui/Icons";
+import { cn } from "@/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+const inputChipVariants = cva(
+  "inline-flex items-center justify-between min-w-[13.813rem] py-2 px-3 h-[2.188rem] text-base font-normal tracking-[-0.01em] leading-[1.216rem] text-gray-dark rounded-lg",
+);
+
+export interface InputChipProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof inputChipVariants> {
+  percentage?: string;
+  selected?: boolean;
+}
+
+const InputChip: React.FC<InputChipProps> = ({
+  percentage,
+  selected = false,
+  className,
+  children,
+  ...props
+}) => {
+  return (
+    <div
+      className={cn(
+        inputChipVariants({
+          className,
+        }),
+        selected ? "bg-purple-light" : "bg-transparent",
+      )}
+      {...props}
+    >
+      <IconRoundedDoc className="text-[#848484]" />
+      {children}
+      {percentage && <p className="font-medium">{percentage}</p>}
+      <button>
+        <IconClose />
+      </button>
+    </div>
+  );
+};
+InputChip.displayName = "InputChip";
+
+export { InputChip };


### PR DESCRIPTION
## 변경사항 및 이유

- InputChip 컴포넌트를 만들었습니다. input 태그에서 입력 후 생기는 컴포넌트라 div 태그를 사용해서 구현하였습니다. 사용하시다가 더 적절한 이름이 생각나신다면 변경 부탁드립니다! 

## 작업 내역

- components > ui 폴더 하위에 InputChip 파일을 추가했습니다.
- InputChip은 2개의 props (optional)를 받습니다. percentage와 selected입니다. percentage를 사용하여 코드 검사가 어느 정도 진행되었는지 보여줍니다. selected는 true일 경우 배경색이 추가되고 false일 경우 투명으로 설정됩니다.

## PR 특이 사항

![InputChip](https://github.com/user-attachments/assets/b6f964a7-daa1-4a7a-b046-a1f2b2092c86)
![사용법](https://github.com/user-attachments/assets/4e7b2492-5566-4f0b-90a8-7ccaa1f4972d)

