### PR TITLE
Modify : Card 컴포넌트 내 Label 컴포넌트 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,22 +8,18 @@
     "ecmaVersion": 11,
     "sourceType": "module"
   },
-
   "plugins": ["react", "react-hooks"],
-
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
     "next",
     "prettier"
   ],
-
   "settings": {
     "react": {
       "version": "detect"
     }
   },
-
   "env": {
     "browser": true,
     "commonjs": true,
@@ -31,26 +27,21 @@
     "node": true,
     "jest": true
   },
-
   "rules": {
     "no-unused-vars": "warn",
     "no-unreachable": "warn",
     "strict": ["error", "global"],
-    // React 17부터 적용 (import React)
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
-    // 추가 React 관련 규칙
     "react/prefer-stateless-function": 0,
     "react/jsx-filename-extension": 0,
     "react/jsx-one-expression-per-line": 0,
     "react/prop-types": 0,
-    // Next/EsLint
     "react/no-unescaped-entities": "off",
     "@next/next/no-page-custom-font": "off",
     "@next/next/no-html-link-for-pages": "off",
     "@next/next/no-img-element": "off",
-    // React Hooks 규칙
-    "react-hooks/rules-of-hooks": "error", // Hook 규칙 검사
-    "react-hooks/exhaustive-deps": "warn" // useEffect Dependencies 검사
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   }
 }

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -204,7 +204,7 @@ function CardCoverImage({
 CardCoverImage.displayName = "CardCoverImage";
 
 // 임시, 껍데기만 개발
-function CardMoreInfoButton({
+function CardLinkButton({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) {
@@ -220,7 +220,7 @@ function CardMoreInfoButton({
     </div>
   );
 }
-CardMoreInfoButton.displayName = "CardMoreInfoButton";
+CardLinkButton.displayName = "CardLinkButton";
 
 function CardFooter({
   className,
@@ -242,6 +242,6 @@ export {
   CardSubTitle,
   CardContent,
   CardCoverImage,
-  CardMoreInfoButton,
+  CardLinkButton,
   CardFooter,
 };

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import Image from "next/image";
 import { cva, VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
@@ -15,13 +14,13 @@ export const CardVariants = cva(`flex flex-col border relative`, {
     },
     size: {
       default:
-        "h-[12.5rem] w-[19.375rem] rounded-xl px-5 py-5 border-primary-100",
+        "h-[12.5rem] w-[19.375rem] rounded-xl border-primary-100 px-5 py-5",
       extended:
-        "h-[13.563rem] w-[26.375rem] px-7 py-7 rounded-lg gap-6 border-[#c3c3c3] [&>*:nth-child(2)]:mt-[-1.25rem]",
-      short: "w-[25.875rem] h-[17.188rem] px-7 py-7 rounded-lg gap-6",
-      long: "w-[54.063rem] h-[15.813rem] px-7 py-7 rounded-lg gap-6",
-      main: "w-[39.063rem] h-[24.375rem] px-9 py-9 rounded-[1.25rem]",
-      sub: "h-[24.375rem] w-[19.75rem] px-9 py-9 rounded-[1.25rem]",
+        "h-[13.563rem] w-[26.375rem] gap-6 rounded-lg border-[#c3c3c3] px-7 py-7 [&>*:nth-child(2)]:mt-[-1.25rem]",
+      short: "h-[17.188rem] w-[25.875rem] gap-6 rounded-lg px-7 py-7",
+      long: "h-[15.813rem] w-[54.063rem] gap-6 rounded-lg px-7 py-7",
+      main: "h-[24.375rem] w-[39.063rem] rounded-[1.25rem] px-9 py-9",
+      sub: "h-[24.375rem] w-[19.75rem] rounded-[1.25rem] px-9 py-9",
     },
   },
   defaultVariants: {

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -4,8 +4,9 @@ import Image from "next/image";
 import { cva, VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 import { IconArrow, IconMenu } from "./Icons";
+import { Label, LabelProps } from "./Label";
 
-export const CardVariants = cva(`flex flex-col border relative`, {
+export const cardVariants = cva(`flex flex-col border relative`, {
   variants: {
     variant: {
       default: "justify-between hover:bg-primary-50",
@@ -29,12 +30,13 @@ export const CardVariants = cva(`flex flex-col border relative`, {
   },
 });
 
-type CardProps = VariantProps<typeof CardVariants> & {
+type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
 };
 
 type CardHeaderProps = React.HTMLAttributes<HTMLDivElement> & {
-  label?: string;
+  labelType?: LabelProps["variant"];
+  labelText?: string;
   hasMenu?: boolean;
 };
 
@@ -50,17 +52,22 @@ type CardContentProps = React.HTMLAttributes<HTMLDivElement> & {
 };
 
 function Card({ variant, size, ...props }: CardProps) {
-  return <div className={cn(CardVariants({ variant, size }))} {...props} />;
+  return <div className={cn(cardVariants({ variant, size }))} {...props} />;
 }
 Card.displayName = "Card";
 
 function CardHeader({
-  label = "label",
+  labelType = "hot",
+  labelText = "HOT",
   hasMenu = false,
   className,
   children,
   ...props
 }: CardHeaderProps) {
+  const newLabelText =
+    labelType === "hot" || labelType === "new"
+      ? labelType.toUpperCase()
+      : labelText;
   return (
     <div
       className={cn(
@@ -70,8 +77,7 @@ function CardHeader({
       )}
       {...props}
     >
-      {/* 임시, Label 컴포넌트 자리 */}
-      <div>{label}</div>
+      <Label variant={labelType}>{newLabelText}</Label>
       {children}
       {hasMenu && <IconMenu />}
     </div>

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -30,24 +30,24 @@ export const cardVariants = cva(`flex flex-col border relative`, {
   },
 });
 
-type CardProps = VariantProps<typeof cardVariants> & {
+export type CardProps = VariantProps<typeof cardVariants> & {
   children?: React.ReactNode;
 };
 
-type CardHeaderProps = React.HTMLAttributes<HTMLDivElement> & {
+export type CardHeaderProps = React.HTMLAttributes<HTMLDivElement> & {
   labelType?: LabelProps["variant"];
   labelText?: string;
   hasMenu?: boolean;
 };
 
-type CardTitleProps = React.HTMLAttributes<HTMLDivElement> & {
+export type CardTitleProps = React.HTMLAttributes<HTMLDivElement> & {
   size?: "big" | "small" | "xsmall" | "default";
   weight?: "bold" | "default";
   color?: string;
   isSingleLine?: boolean;
 };
 
-type CardContentProps = React.HTMLAttributes<HTMLDivElement> & {
+export type CardContentProps = React.HTMLAttributes<HTMLDivElement> & {
   bgColor?: "white" | "transparent" | "default";
 };
 


### PR DESCRIPTION
## 변경사항 및 이유
- Card.tsx 안의 CardHeader 컴포넌트에 Label 컴포넌트 추가
- .eslintrc.json 내부에 공백, 주석 제거 -> JSON 파일은 주석 허용 안 됩니다

## 작업 내역
- Card 컴포넌트(이하 Card로 약칭) 개발 완료
- Card는 총 6가지 유형을 표현할 수 있게 설계되었습니다. ( CardWithImage는 시스템 내부에서 쓰이지 않아 배제함 )
- Card의 variant는 크게 3가지로 나뉘고, variant 안에서 크기에 따라 2가지로 나뉩니다.
### Card의 props
#### variant (하단 그림 참조)
> - **default**: My Library에서 쓰이는 카드
> - **article**: 취약점 DB에서 article 단위로 쓰이는 카드
> - **image**: 취약점 DB에서 thumbnail로 쓰이는 카드
![Group 1437257969 (1)](https://github.com/user-attachments/assets/2f1c99fd-07f1-497c-abe2-081dd6af8ef1)
### Card
#### size (사이즈별 그림 참조)
Card는 각 variant별로 2가지의 size를 갖습니다.
>  - **default, extended**: My Library에서 쓰이는 기본 카드, 큰 카드
  ![Group 1437257969 (3)](https://github.com/user-attachments/assets/d88662ad-7078-4b5a-8148-b4a8f9d05e3b)
> - **long, short**: 취약점 DB에서 article 단위로 쓰이는 롱카드, 숏카드
  ![Group 1437257970](https://github.com/user-attachments/assets/a06dde8c-c18c-4e53-8e98-00a0460284e9)
> - **main, sub**: 취약점 DB에서 thumbnail로 쓰이는 큰 카드, 작은 카드
  ![Group 1437257971](https://github.com/user-attachments/assets/60d2f495-693f-41cd-9cc9-8c22e8300370)

### Card 사용법
- Card는 다음과 같은 식으로 사용하면 됩니다.
```
// Card Image Main의 경우,
<Card variant="image" size="main"> // variant, size 명시
  <CardCoverImage src="/bridge.jpg" alt="thumbnail" /> // ☆alt 속성 반드시 명시☆ 
  <CardFooter> // content가 하단에 위치해서 CardFooter로 감싸줌
    <CardTitleWrapper> // Title, SubTitle은 TitleWrapper로 감싸줌
      <CardTitle size="big" weight="bold" color="white"> // title의 size(big: 28px), weight, color 명시
        제목
      </CardTitle>
      <CardSubTitle>subtitle</CardSubTitle>
    </CardTitleWrapper>
    <CardLinkButton /> // LinkButton도 Footer에 포함
  </CardFooter>
</Card>
```

```
// Card Article Long의 경우,
<Card variant="article" size="long">
  <CardHeader> // 헤더는 반드시 Label을 포함합니다. 단, default가 "hot"으로 설정되어 있어 표기하지 않으면 hot으로 자동 설정됩니다.
    <CardTitle size="small"> // title의 size(small: 20px) 명시
      {`[취약성 경고] Microsoft의 여러  보안 취약점에 대한 CNNVD의 보고서]`}
    </CardTitle>
    <CardSubTitle isSingleLine>Microsoft</CardSubTitle> // subtitle의 isSingleLine true 설정, 화면에서 한 줄 영역을 차지합니다.
  </CardHeader>
  <CardContent>자세한 글 내용</CardContent> // content에서 bgColor를 지정해줄 수 있습니다. (default: bggray.light, white, transparent)
  <CardFooter> // 하단의 친구들은 푸터로 감싸줍니다.
    <div className="flex gap-3"> // 아이콘들을 감싸줍니다.
      <IconPin width={28} height={28} />
      <IconExternalLink />
    </div>
    <CardSubTitle>2일 전</CardSubTitle>
  </CardFooter>
</Card>
```
```
// Card Article Short의 경우,
<Card variant="article" size="short">
  {/* <CardCoverImage src={src} alt="cover" className="rounded-lg opactiy-[0.84]" /> */} // 이미지 필요한 경우 여기에 추가
  <CardHeader labelType="new">
    <CardTitle>
      {`[취약성 경고] Microsoft의 여러  보안 취약점에 대한 CNNVD의 보고서]`}{" "}
    </CardTitle>
  </CardHeader>
  <CardSubTitle size="big" isSingleLine>
    간략한 글 내용
  </CardSubTitle>
  <CardFooter>
    <div className="inline-flex gap-4">
      <IconPin />
      <IconShare />
    </div>
    <CardSubTitle>2일 전</CardSubTitle>
  </CardFooter>
</Card>
```
![image](https://github.com/user-attachments/assets/b1158d5d-70dc-4769-b68b-1f61d0de674e)

```
// Card Default Extened의 경우,
<Card size="extended">
  <CardHeader labelType="unselected" labelText="label" /> // 헤더에서 "hot" label을 쓰지 않는 경우에는 labelType, labelText를 지정해주어야 합니다.
  <CardTitle className="flex-none">Card Title</CardTitle> // title과 subtitle을 일정하게 정렬하고 싶지 않은 경우에는 wrapper 없이 그대로 씁니다.
  <CardSubTitle>Card Subtitle</CardSubTitle>
</Card>
```

## PR 특이 사항
- CardCoverImage 컴포넌트 사용 시 **반드시 alt 속성을 표기**해야 합니다
- CardHeader 속성: 
  - labelType: Label 컴포넌트의 variant 설정, default: "hot"
  - labelText: Label의 내용, default: "HOT"
  - hasMenu: 헤더 내 메뉴 있는지 여부 (true면 IconMenu 출력), default: false
 - CardTitle 속성:
   - size: default (24px) | xsmall (18px) | small (20px) | big (28px)
   - weight: default (500) | bold (600)
- CardSubTitle 속성:
   - size: default (16px) | small (12px)
   - isSingleLine: 텍스트가 한 줄을 모두 차지할지 여부 (true면 한 줄로 나옴), default: false
- CardContent 속성:
  - bgColor: default (연한 회색, colors.bggray.light) | white | transparent