### PR TITLE
Feat : Ranking 컴포넌트 추가

### DIFF
--- a/src/components/ui/InputChip.tsx
+++ b/src/components/ui/InputChip.tsx
@@ -7,12 +7,11 @@ const inputChipVariants = cva(
   "inline-flex items-center justify-between min-w-[13.813rem] py-2 px-3 h-[2.188rem] text-base font-normal tracking-[-0.01em] leading-[1.216rem] text-gray-dark rounded-lg",
 );
 
-export interface InputChipProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof inputChipVariants> {
-  percentage?: string;
-  selected?: boolean;
-}
+export type InputChipProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof inputChipVariants> & {
+    percentage?: string;
+    selected?: boolean;
+  };
 
 const InputChip: React.FC<InputChipProps> = ({
   percentage,

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -36,9 +36,8 @@ const labelVariants = cva(
   },
 );
 
-export interface LabelProps
-  extends React.LabelHTMLAttributes<HTMLLabelElement>,
-    VariantProps<typeof labelVariants> {}
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement> &
+  VariantProps<typeof labelVariants> & {};
 
 const Label: React.FC<LabelProps> = ({
   className,

--- a/src/components/vulnerability-db/Ranking.tsx
+++ b/src/components/vulnerability-db/Ranking.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import * as React from "react";
+
+export type RankingProps = React.HTMLAttributes<HTMLUListElement> & {};
+
+const topics = [
+  "유닛테스트",
+  "웹뷰 프레임워크",
+  "허프만 코딩 구현",
+  "테스트 커버리지",
+  "코드형 인프라(IaC)",
+  "클린 아키텍쳐",
+  "UI 라이브러리 개발",
+  "AWS Personalize",
+  "키클락",
+  "클린 코어",
+];
+
+export const Ranking: React.FC<RankingProps> = ({
+  className,
+  children,
+  ...props
+}) => {
+  const [highlightedTopic, setHighlightedTopic] = React.useState<number>(0);
+
+  React.useEffect(() => {
+    const intervalId = setInterval(() => {
+      setHighlightedTopic((prevIndex) => (prevIndex + 1) % topics.length);
+    }, 5000); // 5초마다 highlightedTopic 변경 (임시)
+
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <ul
+      className={cn(
+        "border-line-default h-[36.25rem] w-[23.625rem] rounded-lg border px-9 py-5",
+        className,
+      )}
+      {...props}
+    >
+      {topics.map((topic, index) => (
+        <li
+          key={index}
+          className={cn(
+            "border-b border-line-light py-4 text-lg font-medium leading-[21.78px] tracking-[-0.01em]",
+            index === topics.length - 1 && "border-none",
+            index === highlightedTopic && "text-primary-500",
+          )}
+        >
+          {index + 1}. {topic}
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,8 +57,9 @@ const config: Config = {
           5: "#F3F3F3",
         },
         line: {
-          light: "#E6E6E6"
-        }
+          default: "#C3C3C3",
+          light: "#E6E6E6",
+        },
       },
     },
   },


### PR DESCRIPTION
## 변경사항 및 이유

- 취약점 DB 페이지에서 사용될 Ranking 컴포넌트를 만들었습니다.
- InputChipProps, LabelProps 인터페이스를 타입으로 변경했습니다.
- tailwind 설정 파일 내 line-default 색상(#C3C3C3)을 추가했습니다.

## 작업 내역
- components > vulnerability-db 폴더 하위에 Ranking 파일을 추가했습니다.
- 아직 api 명세를 못 받았기에 하이라이트 효과 (보라색 글자)는 임시로
 useEffect와 setInterval, clearInterval을 사용하여 5초마다 한 순위씩 내려가도록 적용했습니다. 

## PR 특이 사항
<img src="https://github.com/user-attachments/assets/653d9eba-7735-49f8-8bcd-daabbf73d4d7" width="30%" />


