### PR TITLE
Feat : Landing 페이지에서 사용할 Label 추가

### DIFF
--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -32,6 +32,10 @@ const labelVariants = cva(
         // MY 저장소 - UI 검출된 파일
         "outline-primary":
           "px-[0.75rem] py-[0.438rem] h-[1.875rem] bg-purple-light text-primary-500 font-normal border border-primary-300 leading-4",
+
+        // Landing
+        service:
+          "py-2 px-3 h-[2.875rem] font-medium border text-xl leading-[1.875rem] tracking-[-0.011em]",
       },
     },
     defaultVariants: {
@@ -42,6 +46,11 @@ const labelVariants = cva(
 
 export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement> &
   VariantProps<typeof labelVariants> & {};
+
+export type ServiceLabelProps = React.LabelHTMLAttributes<HTMLLabelElement> &
+  VariantProps<typeof labelVariants> & {
+    color: "pink" | "green" | "purple" | "blue" | "yellow" | "red";
+  };
 
 const Label: React.FC<LabelProps> = ({
   className,
@@ -58,4 +67,39 @@ const Label: React.FC<LabelProps> = ({
 
 Label.displayName = "Label";
 
-export { Label };
+const ServiceLabel: React.FC<ServiceLabelProps> = ({
+  className,
+  variant = "service",
+  color,
+  children,
+  ...props
+}) => {
+  let labelColor = "";
+
+  if (color === "pink") {
+    labelColor = "text-[#FF81A7] bg-[#FFF2F7] border-[#FF81A7]";
+  } else if (color === "green") {
+    labelColor = "text-[#00987C] bg-[#DDFFF3] border-[#00987C]";
+  } else if (color === "purple") {
+    labelColor = "text-[#A54CFF] bg-[#F5E4FF] border-[#A54CFF]";
+  } else if (color === "blue") {
+    labelColor = "text-[#4C93FF] bg-[#E4F2FF] border-[#4C93FF]";
+  } else if (color === "yellow") {
+    labelColor = "text-[#FF8A00] bg-[#FFFBE4] border-[#FF8A00]";
+  } else if (color === "red") {
+    labelColor = "text-[#FF3D00] bg-[#FFEAE4] border-[#FF3D00]";
+  }
+
+  return (
+    <span
+      className={cn(labelVariants({ variant, className }), labelColor)}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+};
+
+ServiceLabel.displayName = "ServiceLabel";
+
+export { Label, ServiceLabel };

--- a/src/components/ui/Ranking.tsx
+++ b/src/components/ui/Ranking.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import * as React from "react";
+import { useEffect, useState } from "react";
 
 export type RankingProps = React.HTMLAttributes<HTMLUListElement> & {};
 
@@ -23,11 +23,13 @@ export const Ranking: React.FC<RankingProps> = ({
   children,
   ...props
 }) => {
-  const [highlightedTopic, setHighlightedTopic] = React.useState<number>(0);
+  const [highlightedTopic, setHighlightedTopic] = useState<number>(0);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const intervalId = setInterval(() => {
-      setHighlightedTopic((prevIndex) => (prevIndex + 1) % topics.length);
+      setHighlightedTopic(
+        (prevIndex: number) => (prevIndex + 1) % topics.length,
+      );
     }, 5000); // 5초마다 highlightedTopic 변경 (임시)
 
     return () => clearInterval(intervalId);


### PR DESCRIPTION
## 변경사항 및 이유

- components > vulnerabiltiy-db 폴더 하위에 있던 Ranking 컴포넌트를 components > ui 폴더 하위로 이동했습니다.
- Landing 페이지의 카드(service card)에서 사용할 label을 추가했습니다. 


## 작업 내역

- Label 파일에서 작업했고, variant로 'service'를 추가했습니다. 'service'라는 이름은 figma 상에서 Layer 이름으로 service card라고 명시되어 있어서 사용하게 되었습니다.
- 기존의 Label 컴포넌트를 수정하지 않고, ServiceLabel 컴포넌트를 만들었습니다. 만약 labelVariants에 color를 추가하게 된다면 기존의 각각 다른 vaiant도 color를 빼주어야 하는데 Label을 이미 사용 중이시고 시간 대비 효율적인 작업은 아니라 생각했습니다.
- ServiceLabel 컴포넌트는 props로 color를 필수로 받고 있습니다. ( 아래 이미지 좌측부터 'pink', 'green', 'purple', 'blue', 'yellow', 'red' 입니다.)
- variant는 ServiceLabel 컴포넌트 만들 때 props 기본값으로 설정했습니다. color만 추가해서 사용 부탁드립니다!

## PR 특이 사항

![service_label](https://github.com/user-attachments/assets/24bbfe75-3324-4994-9024-0d72dbbc255b)

<br/>

예시 코드는 다음과 같습니다.

```
        <ServiceLabel color="pink">보안 강화</ServiceLabel>
        <ServiceLabel color="green">미션 크리티컬한 개발에 적합</ServiceLabel>
        <ServiceLabel color="purple">실시간 보안 업데이트</ServiceLabel>
        <ServiceLabel color="blue">사용자 데이터 보호</ServiceLabel>
        <ServiceLabel color="yellow">효율적인 개발</ServiceLabel>
        <ServiceLabel color="red">신속한 대응과 수정</ServiceLabel>
```
