### PR TITLE
Feat : ArticleDetail 컴포넌트 추가

### DIFF
--- a/src/components/vulnerability-db/ArticleDetail.tsx
+++ b/src/components/vulnerability-db/ArticleDetail.tsx
@@ -1,0 +1,48 @@
+import { ArticleDetailProps } from "@/types/type";
+import { IconPin, IconShare } from "../ui/Icons";
+import { Label } from "../ui/Label";
+
+export default function ArticleDetail({
+  title,
+  content,
+  createdAt,
+  showLabel = true,
+  labelVariant = "hot",
+  labelText = "HOT",
+}: ArticleDetailProps) {
+  const displayLabelText =
+    labelVariant === "hot"
+      ? "HOT"
+      : labelVariant === "new"
+        ? "NEW"
+        : labelText?.toUpperCase() || "HOT";
+  return (
+    <>
+      <div className="mb-[3.75rem] h-[15.154rem] w-[82.125rem] gap-8 border-b border-b-gray-500 p-[1.75rem_0_3.75rem_0]">
+        {showLabel && (
+          <Label variant={labelVariant} className="mb-[1.216rem]">
+            {displayLabelText}
+          </Label>
+        )}
+        <h1 className="mb-8 text-4xl font-medium leading-[2.723rem]">
+          {title}
+        </h1>
+        <div className="flex items-center justify-between text-xl font-normal leading-[1.512rem] text-gray-default">
+          <div className="flex gap-9">
+            <span>취약성 뉴스 세부정보</span>
+            <span>출시시간 | {createdAt}</span>
+          </div>
+          <div className="flex gap-[1.625rem]">
+            <IconShare color="fill-primary-500" />
+            <IconPin color="fill-primary-500" />
+          </div>
+        </div>
+      </div>
+      <div className="mx-auto mb-[3.75rem] h-[43.75rem] w-[82.125rem] gap-[0.625rem] border-b border-b-gray-500 pb-[3.75rem]">
+        <div className="px-[0.938rem] text-2xl font-normal leading-[2.25rem]">
+          <p>{content}</p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/types/type.d.ts
+++ b/src/types/type.d.ts
@@ -1,0 +1,8 @@
+export type ArticleDetailProps = {
+  title: string;
+  content: string;
+  createdAt: string;
+  showLabel?: boolean;
+  labelVariant?: "hot" | "new";
+  labelText?: string;
+};


### PR DESCRIPTION
## 변경사항 및 이유
- ArticleDetail UI를 만들었습니다.
- ArticleDetailProps Type은 types 폴더에서 관리할 수 있습니다.

## 작업 내역
- components > vulnerability-db 폴더 하위에 ArticleDetail 파일을 추가했습니다.
- 기본적으로 "HOT" 라벨이 표시되지만, 라벨이 필요하지 않은 경우 showLabel 값을 false로 설정하여 라벨 표시를 비활성화할 수 있습니다.
- 각 라벨은 labelVariant 속성을 "hot" 또는 "new"로 설정하여 선택할 수 있습니다.
- 실제 데이터가 변수로 정의된 상황에서의 사용 예시
`<ArticleDetail
  title={title}
  content={content}
  createdAt={createdAt}
  showLabel={true}
  labelVariant="hot"
/> `

## PR 특이 사항
![image](https://github.com/user-attachments/assets/d4aec624-c32f-42a2-8615-162c9412b94a)

