### PR TITLE
Modify : ArticleDetail의 CSS 일부 수정

### DIFF
--- a/src/components/vulnerability-db/ArticleDetail.tsx
+++ b/src/components/vulnerability-db/ArticleDetail.tsx
@@ -33,13 +33,13 @@ export default function ArticleDetail({
             <span>출시시간 | {createdAt}</span>
           </div>
           <div className="flex gap-[1.625rem]">
-            <IconShare color="fill-primary-500" />
-            <IconPin color="fill-primary-500" />
+            <IconShare />
+            <IconPin />
           </div>
         </div>
       </div>
       <div className="mx-auto mb-[3.75rem] h-[43.75rem] w-[82.125rem] gap-[0.625rem] border-b border-b-gray-500 pb-[3.75rem]">
-        <div className="px-[0.938rem] text-2xl font-normal leading-[2.25rem]">
+        <div className="max-h-[43.75rem] overflow-y-auto px-[0.938rem] text-2xl font-normal leading-[2.25rem]">
           <p>{content}</p>
         </div>
       </div>


### PR DESCRIPTION
## 변경사항 및 이유
- 긴 글 내용 처리 : content가 긴 경우 스크롤을 지원하도록 CSS를 수정했습니다.
- 불필요한 속성 제거 : 아이콘 컴포넌트에서 컬러 설정을 제거했습니다.

## 작업 내역
- content 영역의 스크롤 처리 :
content를 감싸는 div에 max-height를 설정하여, 긴 글이 있을 때 스크롤이 가능하도록 하였습니다.
max-height을 초과하면 overflow-y-auto 속성으로 수직 스크롤이 활성화되도록 수정했습니다.

- 아이콘 컴포넌트의 불필요한 속성 제거 :
<IconShare />와 <IconPin /> 컴포넌트에서 기본값으로 사용되어있는 컬러 속성을 제거하였습니다.