### PR TITLE
Feat : 공통 ProgressBar 컴포넌트 추가

### DIFF
--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+
+const calculate = (value: number): number => {
+  return value * 100;
+};
+
+export default function ProgressBar({
+  className,
+  value = 0,
+  indicatorClassName,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & {
+  value?: number;
+  indicatorClassName?: string;
+}) {
+  const percentage = calculate(value);
+
+  return (
+    <div
+      className={cn(
+        "h-[0.75rem] w-[87rem] rounded-lg bg-line-light",
+        className,
+      )}
+      {...props}
+      role="progress"
+      aria-valuenow={percentage}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div
+        className={cn("h-full rounded-lg bg-accent-green", indicatorClassName)}
+        style={{ width: `${percentage}%` }}
+      ></div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경사항 및 이유
- 공통 ProgressBar 컴포넌트 추가 ( 스토리보드에서는 My Library에서만 사용되고 있지만 컴포넌트 특성 상 ui 폴더에 위치 )

## 작업 내역
- ProgressBar의 width는 디자인 시스템을 따라 ```w-[87rem]```으로 고정해두었습니다.
- ProgressBar 컴포넌트에 value 속성에 0부터 1 사이의 진행률(ex. 0.89)을 보내면 진행률 만큼의 퍼센티지가 width로 출력됩니다.

## PR 특이 사항
- ```<ProgressBar value={0.78} />```

![image](https://github.com/user-attachments/assets/49786191-8f9f-40a4-b4d9-80931f75e489)