### PR TITLE
Feat : 공통 InfoBox 컴포넌트 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,4 +14,12 @@
   .flex-between-center {
     @apply flex items-center justify-between;
   }
+
+  .flex-end-center {
+    @apply flex items-center justify-end;
+  }
+
+  .flex-col-start-center {
+    @apply flex flex-col items-start justify-center;
+  }
 }

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -50,9 +50,10 @@ const cardContentVariants = cva("", {
   },
 });
 
-export type CardProps = VariantProps<typeof cardVariants> & {
-  children?: React.ReactNode;
-};
+export type CardProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof cardVariants> & {
+    children?: React.ReactNode;
+  };
 
 export type CardHeaderProps = React.HTMLAttributes<HTMLDivElement> & {
   hasMenu?: boolean;
@@ -68,8 +69,13 @@ export type CardTitleProps = React.HTMLAttributes<HTMLDivElement> & {
 export type CardContentProps = React.HTMLAttributes<HTMLDivElement> &
   VariantProps<typeof cardContentVariants>;
 
-function Card({ variant, size, ...props }: CardProps) {
-  return <div className={cn(cardVariants({ variant, size }))} {...props} />;
+function Card({ variant, size, className, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(cardVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
 }
 Card.displayName = "Card";
 

--- a/src/components/ui/InfoBox.tsx
+++ b/src/components/ui/InfoBox.tsx
@@ -1,0 +1,129 @@
+import { Children } from "react";
+import { cva, VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const colorVariants = {
+  primary: "text-primary-500",
+  red: "text-accent-red",
+  gray: "text-gray-dark",
+  "gray-light": "text-gray-default",
+};
+
+const infoBoxVariants = cva(
+  "flex-col-start-center relative h-fit w-full gap-y-[0.625rem] rounded-xl px-5 py-5",
+  {
+    variants: {
+      variant: {
+        primary: "bg-purple-light",
+        red: "bg-red-light",
+        gray: "bg-bggray-light",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+    },
+  },
+);
+
+const infoBoxTitleVariants = cva("text-2xl font-semibold leading-[1.4]", {
+  variants: {
+    color: colorVariants,
+  },
+  defaultVariants: {
+    color: "primary",
+  },
+});
+
+const infoBoxDescriptionVariants = cva("text-lg font-normal", {
+  variants: {
+    color: colorVariants,
+  },
+  defaultVariants: {
+    color: "gray",
+  },
+});
+
+export type InfoBoxProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof infoBoxVariants>;
+
+export type InfoBoxTextProps = React.HTMLAttributes<HTMLElement> &
+  VariantProps<typeof infoBoxTitleVariants> &
+  VariantProps<typeof infoBoxDescriptionVariants>;
+
+function InfoBox({ variant, className, children, ...props }: InfoBoxProps) {
+  return (
+    <div className={cn(infoBoxVariants({ variant }), className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+function InfoBoxHeader({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("inline-flex items-center gap-x-2", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function InfoBoxTitle({
+  color,
+  className,
+  children,
+  ...props
+}: InfoBoxTextProps) {
+  return (
+    <p className={cn(infoBoxTitleVariants({ color }), className)} {...props}>
+      {children}
+    </p>
+  );
+}
+
+function InfoBoxDescriptionList({
+  color,
+  className,
+  children,
+  ...props
+}: InfoBoxTextProps) {
+  const listStlye =
+    Children.count(children) > 1 ? "ml-5 list-disc" : "list-none";
+  return (
+    <ul
+      className={cn(
+        infoBoxDescriptionVariants({ color }),
+        listStlye,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ul>
+  );
+}
+
+function InfoBoxDescriptionListItem({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLLIElement>) {
+  return (
+    <li className={cn(className)} {...props}>
+      {children}
+    </li>
+  );
+}
+
+export {
+  InfoBox,
+  InfoBoxHeader,
+  InfoBoxTitle,
+  InfoBoxDescriptionList,
+  InfoBoxDescriptionListItem,
+};

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -33,6 +33,10 @@ const labelVariants = cva(
         "outline-primary":
           "px-[0.75rem] py-[0.438rem] h-[1.875rem] bg-purple-light text-primary-500 font-normal border border-primary-300 leading-4",
 
+        // MY 저장소 - InfoBox 위치 찾기
+        location:
+          "px-[0.5rem] py-[0.313rem] max-h-[1.813rem] border-2 border-primary-500 font-semibold tracking-[-0.011em] text-primary-500",
+
         // Landing
         service:
           "py-2 px-3 h-[2.875rem] font-medium border text-xl leading-[1.875rem] tracking-[-0.011em]",


### PR DESCRIPTION
## 변경사항 및 이유
- Label 컴포넌트 variant에 location 추가
  - InfoBox 내부에서 쓸 용도로 추가했습니다!
- 공통 InfoBox 컴포넌트 추가 ( 스토리보드에서는 My Library에서만 사용되고 있지만 컴포넌트 특성 상 ui 폴더에 위치 )

## 작업 내역
- InfoBox의 속성 variant:
  - primary, red, gray (default: primary)
- infoBoxTitle의 속성 color:
  - primary, red, gray, gray-light (default: primary, 보라색)
- infoBoxDescriptionList의 속성 color:
  - primary, red, gray, gray-light (default: gray, 다크 그레이)

## PR 특이 사항
- InfoBoxDescriptionList에 InfoBoxDescriptionListItem이 2개 이상인 경우, list-style-disc가 적용됩니다.
```
<InfoBox variant="red">
  <InfoBoxHeader>
    <InfoBoxTitle color="red">문제 코드</InfoBoxTitle>
    <Label
      variant="location"
      className="border-accent-red text-accent-red"
    >
      위치보기
    </Label>
  </InfoBoxHeader>
  <InfoBoxDescriptionList>
    <InfoBoxDescriptionListItem>
      컬러 코드를 설정할때 이렇게 하게 되면 이런 오류가 생기기때문에
      이렇게 하지 않는게 좋다.
    </InfoBoxDescriptionListItem>
    <InfoBoxDescriptionListItem>
      컬러 코드를 설정할때 이렇게 하게 되면 이런 오류가 생기기때문에
      이렇게 하지 않는게 좋다.
    </InfoBoxDescriptionListItem>
  </InfoBoxDescriptionList>
</InfoBox>
```

![image](https://github.com/user-attachments/assets/c0e5cbb0-45a5-4257-b126-38f7a0775a14)

### InfoBox 사용법
```      
<InfoBox variant="gray">
  <InfoBoxHeader>
    <InfoBoxTitle color="gray">문제 코드</InfoBoxTitle>
    <Label variant="location" className="border-gray-dark text-gray-dark">
      위치보기
    </Label>
  </InfoBoxHeader>
  <InfoBoxDescriptionList color="gray-light">
    <InfoBoxDescriptionListItem>
      컬러 코드를 설정할때 이렇게 하게 되면 이런 오류가 생기기때문에
      이렇게 하지 않는게 좋다.
    </InfoBoxDescriptionListItem>
  </InfoBoxDescriptionList>
</InfoBox>
```

![image](https://github.com/user-attachments/assets/06bd3228-af57-42ff-8d2b-37a773ed2f7a)
