### PR TITLE
Feat : 공통 Input 컴포넌트 추가

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import React, { useState } from "react";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  isErrored?: boolean;
+};
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ isErrored, className, type, ...props }, ref) => {
+    const [isValid, setIsValid] = useState(false);
+
+    const onBlurInput = (e: React.FocusEvent<HTMLInputElement>) => {
+      if (e.target.value && !isErrored) {
+        setIsValid(true);
+      } else {
+        setIsValid(false);
+      }
+    };
+
+    return (
+      <input
+        type={type}
+        onBlur={onBlurInput}
+        className={cn(
+          "placeholder:text-gray-light h-[51px] w-full rounded-lg border p-3 text-lg font-medium text-gray-dark outline-none placeholder:font-medium disabled:cursor-not-allowed disabled:bg-bggray-light",
+          className,
+          isValid
+            ? "bg-purple-light focus:bg-transparent"
+            : isErrored
+              ? "bg-red-light"
+              : "bg-transparent focus:bg-transparent",
+          isErrored
+            ? "border-accent-red"
+            : "border-line-default focus:border-primary-500",
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -38,6 +38,7 @@ const config: Config = {
         gray: {
           default: "#969696",
           dark: "#3F3F3F",
+          light: "#D6D6D6",
         },
         bggray: {
           light: "#F1F1F1",


### PR DESCRIPTION
## 변경사항 및 이유

- Input 컴포넌트를 만들었습니다. 
- tailwind 설정 파일 내 gray-light 색상(`#D6D6D6`)을 추가했습니다.

## 작업 내역

- components > ui 폴더 하위에 Input 파일을 추가했습니다.
- Input은 1개의 prop을 받습니다. 유효성 검사에서 에러가 발생할 경우 isErrored prop을 통해 스타일을 변경합니다. 
- Input의 상태는 default, activated, filled, error, disabled로 만들었습니다. activated는 Input에 focus 되었을 때 그리고 filled는 Input에 focus를 잃고 value가 있을 때의 차이로 구현했습니다.
- focus 상태에 따라 스타일을 변경해야 해서 직접적인 DOM 접근이 필요하여 React.forwardRef를 사용했습니다.


## PR 특이 사항


![input](https://github.com/user-attachments/assets/20c4f773-7cb5-44dc-8cfe-b69a642e1cdb)


예시 코드는 다음과 같습니다.

```
<Input placeholder="Placeholder text" />
<Input placeholder="Placeholder text" isErrored />
<Input placeholder="Placeholder text" disabled />
```


