### PR TITLE
Feat : Status 컴포넌트 추가

### DIFF
--- a/src/components/analyze/Status.tsx
+++ b/src/components/analyze/Status.tsx
@@ -1,29 +1,74 @@
 import { cn } from "@/lib/utils";
 import { IconClose, IconTriangle, IconCircle } from "../ui/Icons";
 
-export default function Status() {
+function Status({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn(
         "flex-center-center h-[4.063rem] w-[15.375rem] gap-x-5 rounded-lg border border-line-default px-5 py-5 text-[1.268rem] font-medium -tracking-[0.01rem]",
+        className,
       )}
+      {...props}
     >
-      <div className="inline-flex items-center gap-x-2">
-        <IconClose
-          width={28}
-          height={28}
-          className="fill-accent-red stroke-accent-red stroke-[0.013rem]"
-        />
-        <span>12</span>
-      </div>
-      <div className="inline-flex items-center gap-x-2">
-        <IconTriangle />
-        <span>13</span>
-      </div>
-      <div className="inline-flex items-center gap-x-2">
-        <IconCircle />
-        <span>12</span>
-      </div>
+      {children}
     </div>
   );
 }
+
+function StatusError({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("inline-flex items-center gap-x-[0.125rem]", className)}
+      {...props}
+    >
+      <IconClose
+        width={28}
+        height={28}
+        className="fill-accent-red stroke-accent-red stroke-[0.013rem]"
+      />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function StatusWarning({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("inline-flex items-center gap-x-2", className)}
+      {...props}
+    >
+      <IconTriangle />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function StatusSuccess({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("inline-flex items-center gap-x-2", className)}
+      {...props}
+    >
+      <IconCircle />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+export { Status, StatusError, StatusWarning, StatusSuccess };

--- a/src/components/analyze/Status.tsx
+++ b/src/components/analyze/Status.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+import { IconClose, IconTriangle, IconCircle } from "../ui/Icons";
+
+export default function Status() {
+  return (
+    <div
+      className={cn(
+        "flex-center-center h-[4.063rem] w-[15.375rem] gap-x-5 rounded-lg border border-line-default px-5 py-5 text-[1.268rem] font-medium -tracking-[0.01rem]",
+      )}
+    >
+      <div className="inline-flex items-center gap-x-2">
+        <IconClose
+          width={28}
+          height={28}
+          className="fill-accent-red stroke-accent-red stroke-[0.013rem]"
+        />
+        <span>12</span>
+      </div>
+      <div className="inline-flex items-center gap-x-2">
+        <IconTriangle />
+        <span>13</span>
+      </div>
+      <div className="inline-flex items-center gap-x-2">
+        <IconCircle />
+        <span>12</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Icons.tsx
+++ b/src/components/ui/Icons.tsx
@@ -392,3 +392,41 @@ export function IconCheck({
     </svg>
   );
 }
+
+export function IconTriangle({
+  className,
+  ...props
+}: React.ComponentProps<"svg">) {
+  return (
+    <svg
+      width="23"
+      height="20"
+      viewBox="0 0 23 20"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("fill-accent-orange", className)}
+      {...props}
+    >
+      <path d="M9.80419 0.958085C10.5579 -0.319361 12.4421 -0.319362 13.1958 0.958083L22.7347 17.1257C23.4884 18.4032 22.5463 20 21.0389 20H1.96108C0.453689 20 -0.488429 18.4032 0.265264 17.1257L9.80419 0.958085Z" />
+    </svg>
+  );
+}
+
+export function IconCircle({
+  className,
+  ...props
+}: React.ComponentProps<"svg">) {
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 22 22"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("fill-accent-green", className)}
+      {...props}
+    >
+      <circle cx="11" cy="11" r="11" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## 변경사항 및 이유
- Icons 컴포넌트에 IconTriangle, IconCircle 추가
- My 저장소에서 코드 취약성 검사 결과의 status별 count를 출력하는 Status 컴포넌트 추가

## 작업 내역
- components > analyze 폴더 하위에 Status 파일을 포함시켰습니다.
- 코드 취약성 검사 결과의 status별 count를 status(Error, Warning, Success)별로 출력할 수 있습니다.

## PR 특이 사항
### Status 사용법
```
const Component = () => {
  const counts = {
    error: 8,
    warning: 12,
    success: 23,
  };

  return(
    <Status>
      <StatusError>{counts.error}</StatusError>
      <StatusWarning>{counts.warning}</StatusWarning>
      <StatusSuccess>{counts.success}</StatusSuccess>
    </Status>
  )
}
```

![image](https://github.com/user-attachments/assets/b1ac7289-9334-4607-99c5-7fd663e42175)