### PR TITLE
Feat: 마이 라이브러리 > 사용자 프로필 조회 페이지 구현

### DIFF
--- a/src/app/my/layout.tsx
+++ b/src/app/my/layout.tsx
@@ -2,7 +2,7 @@ export default function MyLibraryLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <section className="mx-auto mb-[7.75rem] mt-[3.375rem] flex w-[82.125rem] flex-col gap-y-[7.75rem]">
+    <section className="mx-auto mb-[7.75rem] flex w-[82.125rem] flex-col gap-y-[7.75rem]">
       {children}
     </section>
   );

--- a/src/app/my/profile/page.tsx
+++ b/src/app/my/profile/page.tsx
@@ -1,7 +1,100 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Input } from "@/components/ui/Input";
+
 export default function Profile() {
   return (
     <>
-      <h1>Profile</h1>
+      <h1 className="flex-col-center-center mt-[4.5rem] gap-y-5 text-[2.5rem] font-normal leading-[3.026rem] -tracking-[0.01em] text-primary-500">
+        <span className="rounded-full border-[0.25rem] border-primary-500 px-[1.25rem] py-[0.969rem]">
+          Profile Information
+        </span>
+      </h1>
+
+      <div className="flex flex-col gap-y-20">
+        <section className="flex flex-col gap-y-20">
+          <div className="flex-between-center h-[6.688rem] gap-4">
+            {/* User */}
+            <div className="inline-flex items-center gap-x-[2.75rem]">
+              <Image
+                src={"/images/gear.png"}
+                alt="avatar"
+                width={108}
+                height={108}
+                priority
+                className="h-[6.688rem] w-[6.688rem] rounded-[50%]"
+              />
+              <div className="flex-col-start-center text-[2.5rem] font-medium leading-tight -tracking-[0.01em] text-gray-dark">
+                <span>Hello,</span>
+                <span>marry@gmail.com</span>
+              </div>
+            </div>
+            {/* 임시, Button */}
+            <button className="flex-center-center rounded-lg border-2 border-primary-500 px-5 py-4 text-2xl font-medium text-primary-500">
+              로그아웃
+            </button>
+          </div>
+          <hr className="h-[0.063rem] w-full border-[#BABABA]" />
+        </section>
+
+        <section className="flex flex-col gap-y-20">
+          <div className="flex-col-start-center h-full gap-y-12">
+            <h2 className="text-[2rem] font-semibold leading-[2.421rem] -tracking-[0.01em] text-gray-dark">
+              내 정보
+            </h2>
+            <div className="flex flex-col gap-y-4">
+              <span className="text-2xl font-medium leading-[1.816rem] text-gray-dark">
+                계정
+              </span>
+              <Input
+                isErrored={false}
+                value="marry@gmail.com"
+                disabled
+                className="w-[54.125rem] leading-[1.688rem] -tracking-[0.011rem] text-gray-default"
+              />
+            </div>
+          </div>
+          <hr className="h-[0.063rem] w-full border-[#BABABA]" />
+        </section>
+
+        <section className="flex flex-col gap-y-20">
+          <div className="flex-col-start-center h-full gap-y-14">
+            <h2 className="text-[2rem] font-semibold leading-[2.421rem] -tracking-[0.01em] text-gray-dark">
+              라이브러리
+            </h2>
+            <div className="flex flex-col gap-y-9">
+              <Link href="/my/detected-files">
+                <span className="text-2xl font-medium leading-[1.816rem] text-gray-dark">
+                  검출된 파일
+                </span>
+              </Link>
+              <Link href="/my/clipping-articles">
+                <span className="text-2xl font-medium leading-[1.816rem] text-gray-dark">
+                  스크랩
+                </span>
+              </Link>
+            </div>
+          </div>
+          <hr className="h-[0.063rem] w-full border-[#BABABA]" />
+        </section>
+
+        <section className="flex flex-col gap-y-20">
+          <div className="flex-col-start-center h-full gap-y-14">
+            <div className="flex flex-col gap-y-9">
+              <Link href="/my/settings">
+                <span className="text-2xl font-medium leading-[1.816rem] text-gray-dark">
+                  설정
+                </span>
+              </Link>
+              <Link href="/my/customer-service">
+                <span className="text-2xl font-medium leading-[1.816rem] text-gray-dark">
+                  고객센터
+                </span>
+              </Link>
+            </div>
+          </div>
+        </section>
+      </div>
     </>
   );
 }

--- a/src/app/my/repos/page.tsx
+++ b/src/app/my/repos/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Image from "next/image";
-import Dropdown from "@/components/ui/Dropdown";
-import Repo from "@/components/analyze/Repo";
-import { useEffect, useState } from "react";
-import { IconCaretLeft } from "@/components/ui/Icons";
 import Link from "next/link";
+import { useEffect, useState } from "react";
+import Repo from "@/components/analyze/Repo";
+import Dropdown from "@/components/ui/Dropdown";
+import { IconCaretLeft } from "@/components/ui/Icons";
 
 const ITEMS_PER_PAGE = 12;
 const dummyRepos = [
@@ -40,7 +40,7 @@ export default function Repos() {
 
   return (
     <>
-      <h1 className="flex-col-center-center gap-y-5 text-[3.75rem] leading-[1.2] -tracking-[0.01em] text-primary-500">
+      <h1 className="flex-col-center-center mt-[3.5rem] gap-y-5 text-[3.75rem] leading-[1.2] -tracking-[0.01em] text-primary-500">
         <span className="font-light">containing code files</span>
         <span className="rounded-full border-[0.25rem] border-primary-500 px-10 py-[1.156rem] leading-[1.1]">
           My Library


### PR DESCRIPTION
## 변경사항 및 이유
- 내 저장소 > 사용자 프로필 조회 페이지 구현
- app/my/layout.tsx, app/my/repos/page.tsx css 수정

## 작업 내역
- 내 저장소에서 프로필 조회 버튼을 클릭하여 접근할 수 있는 사용자 프로필 조회 페이지를 구현했습니다.

## PR 특이 사항
- 구현 화면
- 버튼은 공통 컴포넌트를 쓸 예정이라 일시적으로만 구현했습니다.
- 사용자 아바타 이미지는 public/images에 있는 이미지 아무거나 갖다 썼습니다.
- 로그아웃 기능은 구현하지 않았습니다.

![image](https://github.com/user-attachments/assets/f4171357-62fe-48cd-8d61-2bc49c352faf)