### PR TITLE
Feat : 고객센터 컴포넌트 추가

### DIFF
--- a/src/app/my/customer-service/page.tsx
+++ b/src/app/my/customer-service/page.tsx
@@ -1,7 +1,14 @@
-export default function CustomerService() {
+import CustomerService from "@/components/ui/CustomerService";
+import { IconCaretLeft } from "@/components/ui/Icons";
+
+export default function CustomerServicePage() {
   return (
     <>
-      <h1>CustomerService</h1>
+      <button className="flex-center-center mx-auto mt-[4.5rem] h-[4.938rem] w-[35.125rem] gap-5 rounded-full border-4 border-primary-500 p-5 text-[2.5rem] font-normal leading-[3rem] tracking-[-0.01em] text-primary-500">
+        <IconCaretLeft />
+        <span>Customer Service center</span>
+      </button>
+      <CustomerService />
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function LandingPage() {
   return (
     <>
       <Section1 />
-      <CustomerService />
+      <CustomerService className="my-[6.5rem]" />
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,11 @@
 import Section1 from "@/components/landing/Section1";
+import CustomerService from "@/components/ui/CustomerService";
 
 export default function LandingPage() {
   return (
     <>
       <Section1 />
+      <CustomerService />
     </>
   );
 }

--- a/src/components/ui/CustomerService.tsx
+++ b/src/components/ui/CustomerService.tsx
@@ -1,32 +1,27 @@
-"use client";
-
 import { cn } from "@/lib/utils";
-import { usePathname } from "next/navigation";
 import { Input } from "./Input";
 import { TextArea } from "./TextArea";
 
-export default function CustomerService() {
-  const pathName = usePathname();
-
+export default function CustomerService({ className }: { className?: string }) {
   return (
     <section
       className={cn(
-        "mx-auto flex h-[51.063rem] justify-between",
-        pathName === "/" ? "my-[6.5rem] w-[96.125rem]" : "w-full", // landing 페이지와 고객 센터 페이지의 레이아웃을 다르게 설정
+        "mx-auto flex h-[46rem] w-full max-w-[82.125rem] justify-between gap-[6.875rem]",
+        className,
       )}
     >
-      <div className="h-full w-[28.125rem]">
-        <h2 className="text-6xl font-bold leading-[5.625rem] tracking-tighter text-primary-500">
+      <div className="h-full w-[25.625rem]">
+        <h2 className="text-5xl font-bold leading-[4.375rem] tracking-tighter text-primary-500">
           서비스 이용에
           <br />
           문제가 생겼나요?
         </h2>
-        <p className="mt-8 text-xl font-medium leading-8 text-gray-default">
+        <p className="mt-8 text-lg font-medium leading-8 text-gray-default">
           이용하면서 문제가 생겼다면 언제든지 문의주세요. 서비스 개발과 성장에
           큰 도움이 됩니다.
         </p>
-        <ul className="mt-[22.5rem] h-[11.313rem]">
-          <li className="mb-[3.188rem] flex flex-col gap-2">
+        <ul className="mt-[20.625rem]">
+          <li className="mb-8 flex flex-col gap-2">
             <span className="text-xl font-semibold leading-[1.875rem] text-gray-dark">
               Email
             </span>
@@ -46,12 +41,11 @@ export default function CustomerService() {
       </div>
       <form
         className={cn(
-          "flex h-full flex-col gap-8 rounded-[40px] border border-primary-500 bg-white p-[3.75rem]",
-          pathName === "/" ? "w-[61.563rem]" : "w-[47.563rem]", // landing 페이지와 고객 센터 페이지에서 form 레이아웃을 다르게 설정
+          "flex h-full w-full max-w-[49.625rem] flex-col gap-6 rounded-[2.5rem] border border-primary-500 bg-white px-12 py-10",
         )}
       >
         <div>
-          <h3 className="mb-5 text-2xl font-bold leading-9">문의하기</h3>
+          <h3 className="mb-2 text-2xl font-bold leading-9">문의하기</h3>
           <p className="text-base font-medium tracking-[-0.011em] text-[#8F8F8F]">
             문의하고싶은 내용을 구체적으로 작성해주셔야 피드백이 정상적으로
             반영됩니다.
@@ -90,7 +84,7 @@ export default function CustomerService() {
           <TextArea
             id="message"
             placeholder="내용을 적어주세요."
-            className="mt-2 h-[14.125rem]"
+            className="mt-2 h-56"
           />
         </div>
         <button className="rounded-lg bg-primary-500 py-[0.813rem] text-lg font-semibold text-white">

--- a/src/components/ui/CustomerService.tsx
+++ b/src/components/ui/CustomerService.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { usePathname } from "next/navigation";
+import { Input } from "./Input";
+import { TextArea } from "./TextArea";
+
+export default function CustomerService() {
+  const pathName = usePathname();
+
+  return (
+    <section
+      className={cn(
+        "mx-auto flex h-[51.063rem] justify-between",
+        pathName === "/" ? "my-[6.5rem] w-[96.125rem]" : "w-full", // landing 페이지와 고객 센터 페이지의 레이아웃을 다르게 설정
+      )}
+    >
+      <div className="h-full w-[28.125rem]">
+        <h2 className="text-6xl font-bold leading-[5.625rem] tracking-tighter text-primary-500">
+          서비스 이용에
+          <br />
+          문제가 생겼나요?
+        </h2>
+        <p className="mt-8 text-xl font-medium leading-8 text-gray-default">
+          이용하면서 문제가 생겼다면 언제든지 문의주세요. 서비스 개발과 성장에
+          큰 도움이 됩니다.
+        </p>
+        <ul className="mt-[22.5rem] h-[11.313rem]">
+          <li className="mb-[3.188rem] flex flex-col gap-2">
+            <span className="text-xl font-semibold leading-[1.875rem] text-gray-dark">
+              Email
+            </span>
+            <span className="text-lg font-normal text-gray-default">
+              justin@floatfactory.kr
+            </span>
+          </li>
+          <li className="flex flex-col gap-2">
+            <span className="text-xl font-semibold leading-[1.875rem] text-gray-dark">
+              Adress
+            </span>
+            <span className="text-lg font-normal text-gray-default">
+              서울 강서구 마곡중앙2로 11 305호
+            </span>
+          </li>
+        </ul>
+      </div>
+      <form
+        className={cn(
+          "flex h-full flex-col gap-8 rounded-[40px] border border-primary-500 bg-white p-[3.75rem]",
+          pathName === "/" ? "w-[61.563rem]" : "w-[47.563rem]", // landing 페이지와 고객 센터 페이지에서 form 레이아웃을 다르게 설정
+        )}
+      >
+        <div>
+          <h3 className="mb-5 text-2xl font-bold leading-9">문의하기</h3>
+          <p className="text-base font-medium tracking-[-0.011em] text-[#8F8F8F]">
+            문의하고싶은 내용을 구체적으로 작성해주셔야 피드백이 정상적으로
+            반영됩니다.
+          </p>
+        </div>
+        <div>
+          <label
+            htmlFor="name"
+            className="text-lg font-medium leading-[1.688rem]"
+          >
+            Name
+          </label>
+          <Input id="name" placeholder="이름을 적어주세요." className="mt-2" />
+        </div>
+        <div>
+          <label
+            htmlFor="email"
+            className="text-lg font-medium leading-[1.688rem]"
+          >
+            Email
+          </label>
+          <Input
+            id="email"
+            placeholder="justin@floatfactory.kr"
+            disabled
+            className="mt-2"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="message"
+            className="text-lg font-medium leading-[1.688rem]"
+          >
+            Message
+          </label>
+          <TextArea
+            id="message"
+            placeholder="내용을 적어주세요."
+            className="mt-2 h-[14.125rem]"
+          />
+        </div>
+        <button className="rounded-lg bg-primary-500 py-[0.813rem] text-lg font-semibold text-white">
+          문의 보내기
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/ui/TextArea.tsx
+++ b/src/components/ui/TextArea.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import React, { useState } from "react";
+
+export type TextAreaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+    isErrored?: boolean;
+  };
+
+const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  ({ isErrored, className, ...props }, ref) => {
+    const [isValid, setIsValid] = useState(false);
+
+    const onBlurTextArea = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+      if (e.target.value && !isErrored) {
+        setIsValid(true);
+      } else {
+        setIsValid(false);
+      }
+    };
+
+    return (
+      <textarea
+        onBlur={onBlurTextArea}
+        className={cn(
+          "h-[220px] w-full resize-none rounded-lg border p-3 text-lg font-medium text-gray-dark outline-none placeholder:font-medium placeholder:text-gray-light disabled:cursor-not-allowed disabled:bg-bggray-light",
+          className,
+          isValid
+            ? "bg-purple-light focus:bg-transparent"
+            : isErrored
+              ? "bg-red-light"
+              : "bg-transparent focus:bg-transparent",
+          isErrored
+            ? "border-accent-red"
+            : "border-line-default focus:border-primary-500",
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+TextArea.displayName = "TextArea";
+
+export { TextArea };


### PR DESCRIPTION
## 변경사항 및 이유

- 고객센터 UI를 완성했습니다.

## 작업 내역

- 고객센터 form을 만들기 위해 공통 컴포넌트 Input을 사용하였고 추가로 TextArea를 ui 컴포넌트에 추가하였습니다.  
- CustomerService 컴포넌트는 `/` 페이지와 `my/customer-service` 페이지에서 사용되어서 ui 컴포넌트 하위에 추가하였습니다.



## PR 특이 사항

+  `/` 페이지에 적용한 결과입니다.


![screencapture-localhost-3000-2024-08-20-13_36_55](https://github.com/user-attachments/assets/7d1a12b1-e1fc-43b3-98fe-45e6e5d4ad21)


<br/>
<br/>

+ `my/customer-service` 페이지에 적용한 결과입니다.


![screencapture-localhost-3000-my-customer-service-2024-08-20-13_36_37](https://github.com/user-attachments/assets/d5f4263e-5d81-4ebc-9c9e-4955c186abf7)



