### PR TITLE
Feat : 랜딩 페이지 Section 3 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,4 +36,8 @@
   .flex-col-center-center {
     @apply flex flex-col items-center justify-center;
   }
+
+  .flex-col-end-center {
+    @apply flex flex-col items-end justify-center;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import Section1 from "@/components/landing/Section1";
+import Section3 from "@/components/landing/Section3";
 import CustomerService from "@/components/ui/CustomerService";
 
 export default function LandingPage() {
   return (
     <>
       <Section1 />
+      <Section3 />
       <CustomerService className="my-[6.5rem]" />
     </>
   );

--- a/src/components/analyze/ProcessStatus.tsx
+++ b/src/components/analyze/ProcessStatus.tsx
@@ -9,7 +9,7 @@ interface ProcessStatusProps extends StatusVariantsProps {
 }
 
 const statusVariants = cva(
-  "mb-8 w-full max-w-[20rem] rounded-lg border py-[0.625rem] text-center text-xl",
+  "mb-8 w-full max-w-[25.625rem] max-h-[2.75rem] rounded-lg border py-[0.625rem] text-center text-xl",
   {
     variants: {
       status: {
@@ -35,7 +35,7 @@ export default function ProcessStatus({
     <div className="flex w-full flex-col items-center">
       <div className="mb-6">
         {status === "inProgress" ? (
-          <IconOnProcess className="animate-spin" size={40}/>
+          <IconOnProcess className="animate-spin" size={40} />
         ) : (
           <IconDone />
         )}

--- a/src/components/analyze/Status.tsx
+++ b/src/components/analyze/Status.tsx
@@ -9,7 +9,7 @@ function Status({
   return (
     <div
       className={cn(
-        "flex-center-center h-[4.063rem] w-[15.375rem] gap-x-5 rounded-lg border border-line-default px-5 py-5 text-[1.268rem] font-medium -tracking-[0.01rem]",
+        "flex-center-center h-[4.063rem] w-[15.375rem] gap-x-5 rounded-lg border border-line-default p-5 text-[1.268rem] font-medium -tracking-[0.01rem]",
         className,
       )}
       {...props}

--- a/src/components/landing/Section3.tsx
+++ b/src/components/landing/Section3.tsx
@@ -1,0 +1,55 @@
+import { exampleCode } from "@/lib/dummy";
+import ProcessStatus from "../analyze/ProcessStatus";
+import Button from "../ui/Button";
+
+export default function Section3() {
+  return (
+    <section className="flex-end-center relative max-h-screen min-h-dvh w-full overflow-y-clip px-[9.063rem]">
+      <article className="absolute left-[12rem] top-[5.7rem] w-[45.313rem] overflow-x-visible rounded-lg border border-neutral-30 p-10">
+        <div className="flex h-[61rem] flex-col">
+          <ProcessStatus status="inProgress" />
+          <div>
+            <code className="block size-full whitespace-pre-wrap text-sm font-medium leading-tight -tracking-[0.011em] blur-[6px]">
+              {exampleCode}
+            </code>
+            <Button
+              variant="filled"
+              shape="rounded"
+              className="absolute top-[15.7%] z-50 translate-x-[42%] whitespace-nowrap bg-primary-300 px-[0.625rem] py-2 font-normal shadow-[0_1.5rem_2.25rem_0_rgba(0,0,0,0.25)]"
+            >
+              SectionBusinessForever from
+              "@/components/section-business-forever";
+            </Button>
+            <Button
+              variant="filled"
+              shape="rounded"
+              className="absolute top-[29%] z-50 translate-x-[56.5%] bg-primary-300 px-[0.625rem] py-2 font-normal shadow-[0_1.5rem_2.25rem_0_rgba(0,0,0,0.25)]"
+            >
+              "flex flex-col items-center py-36 min-h-screen"
+            </Button>
+            <Button
+              variant="filled"
+              shape="rounded"
+              className="absolute bottom-[27.4%] z-50 translate-x-[27%] bg-primary-300 px-[0.625rem] py-2 font-normal shadow-[0_1.5rem_2.25rem_0_rgba(0,0,0,0.25)]"
+            >
+              Card className
+            </Button>
+          </div>
+        </div>
+      </article>
+      <article className="mt-[7%] flex w-fit flex-col gap-y-[2.125rem]">
+        <p className="flex-col-end-center w-full space-y-3 truncate text-[3.75rem] font-bold leading-[4.538rem] -tracking-[0.011em] text-primary-500">
+          <span>최신 보안 동향을</span>
+          <span>실시간으로 확인하세요.</span>
+        </p>
+        <p className="flex-col-end-center w-full space-y-2 text-xl font-medium leading-[1.513rem] -tracking-[0.011em] text-gray-default">
+          <span>실시간으로 최신 보안 동향을 제공하여</span>
+          <span>개발자들이 보안 취약점에 대한 최신 정보를 받을 수 있어</span>
+          <span>
+            보안 강화를 위한 코딩 관행을 지속적으로 개선할 수 있습니다.
+          </span>
+        </p>
+      </article>
+    </section>
+  );
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -16,14 +16,13 @@ const cardVariants = cva("relative flex flex-col", {
         "justify-center items-center shadow-[0_5rem_3.75rem_-2.5rem_rgba(0,0,0,0.25)]",
     },
     size: {
-      default:
-        "h-[12.5rem] w-[19.375rem] rounded-xl border-primary-100 px-5 py-5",
+      default: "h-[12.5rem] w-[19.375rem] rounded-xl border-primary-100 p-5",
       extended:
-        "h-[13.563rem] w-[26.375rem] gap-6 rounded-lg border-[#c3c3c3] px-7 py-7 [&>*:nth-child(2)]:mt-[-1.25rem]",
-      short: "h-[17.188rem] w-[25.875rem] gap-6 rounded-lg px-7 py-7",
-      long: "h-[16.125rem] w-[54.063rem] gap-6 rounded-lg px-7 py-7",
-      main: "h-[24.375rem] w-[39.063rem] rounded-[1.25rem] px-9 py-9",
-      sub: "h-[24.375rem] w-[19.75rem] rounded-[1.25rem] px-9 py-9",
+        "h-[13.563rem] w-[26.375rem] gap-6 rounded-lg border-[#c3c3c3] p-7 [&>*:nth-child(2)]:mt-[-1.25rem]",
+      short: "h-[17.188rem] w-[25.875rem] gap-6 rounded-lg p-7",
+      long: "h-[16.125rem] w-[54.063rem] gap-6 rounded-lg p-7",
+      main: "h-[24.375rem] w-[39.063rem] rounded-[1.25rem] p-9",
+      sub: "h-[24.375rem] w-[19.75rem] rounded-[1.25rem] p-9",
       service: "h-[28.829rem] w-[21.208rem] rounded-[2.5rem]",
     },
   },
@@ -36,7 +35,7 @@ const cardVariants = cva("relative flex flex-col", {
 const cardContentVariants = cva("", {
   variants: {
     variant: {
-      default: "h-[3.688rem] w-full rounded-2xl px-5 py-5",
+      default: "h-[3.688rem] w-full rounded-2xl p-5",
       emoji: "flex-center-center mb-[2.344rem] mt-[1.694rem] h-fit w-full",
     },
     bgColor: {

--- a/src/components/ui/InfoBox.tsx
+++ b/src/components/ui/InfoBox.tsx
@@ -10,7 +10,7 @@ const colorVariants = {
 };
 
 const infoBoxVariants = cva(
-  "flex-col-start-center relative h-fit w-full gap-y-[0.625rem] rounded-xl px-5 py-5",
+  "flex-col-start-center relative h-fit w-full gap-y-[0.625rem] rounded-xl p-5",
   {
     variants: {
       variant: {

--- a/src/lib/dummy.ts
+++ b/src/lib/dummy.ts
@@ -1,0 +1,37 @@
+export const exampleCode = `import SectionBusinessForever from "@/components/section-business-forever";
+import SectionVideoDisplayer from "@/components/section-video-displayer";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import Image from "next/image";
+
+export default function Home() {
+  return (
+    <main className="flex flex-col items-center py-36 min-h-screen"
+    // only background brightness is 0.5
+      style={{ background: "linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/bg.svg')", backgroundSize: "cover", backgroundPosition: "center"}}>
+      <hgroup className="flex flex-col items-center py-16 gap-4 z-10">
+        <Badge>Systemable</Badge>
+        <h1 className="text-6xl font-bold">Build once, Business forever</h1>
+        <p className="text-sm">
+          We help businesses to grow and scale by providing them with the right
+          tools and resources.
+        </p>
+      </hgroup>
+      <div className="z-10 grid grid-cols-2 max-w-4xl mx-auto gap-4 my-24">
+        <Card className="bg-transparent backdrop-blur-sm col-span-2">
+          <CardHeader>
+            <CardTitle>Analyze</CardTitle>
+            <CardDescription>
+              We analyze your business processes and provide you with the right ways to make sure your business is running smoothly.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle>Systemize</CardTitle>
+            <CardDescription>
+              We find the ways to systemize your business processes to make sure you are not wasting time on repetitive tasks.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="bg-transparent backdrop-blur-sm">`;


### PR DESCRIPTION
## 변경사항 및 이유
- 랜딩페이지의 3 섹션 구현
- globals.css에 레이아웃 추가
- blur 처리되는 더미 코드 파일 lib 폴더 하위에 추가
- 공통 컴포넌트 css 수정

## 작업 내역
- ProcessStatus 컴포넌트의 너비와 높이를 수정했습니다.
- 두 번 쓸 필요 없는 클래스를 합쳤습니다. (ex. px-5, py-5 -> p-5로 통일)
  -> Status, Card, InfoBox

## PR 특이 사항
- 구현 화면
- 피그마에 적용된 한글 폰트와 시스템의 한글 폰트가 달라서 화면이 다르게 출력되는 점 양해 부탁드립니다.

![image](https://github.com/user-attachments/assets/81348850-8819-4740-9440-ec8e4d82cd3e)
