### PR TITLE
Feat : 공통 Modal 컴포넌트 추가

### DIFF
--- a/src/app/analyze/[id]/page.tsx
+++ b/src/app/analyze/[id]/page.tsx
@@ -9,8 +9,10 @@ import {
 } from "@/components/analyze/Status";
 import Button from "@/components/ui/Button";
 import { InputChip } from "@/components/ui/InputChip";
+import Modal from "@/components/ui/Modal";
 import ProgressBar from "@/components/ui/ProgressBar";
 import TitleBar from "@/components/ui/TitleBar";
+import { useState } from "react";
 
 export default function Analyze() {
   const counts = {
@@ -19,11 +21,28 @@ export default function Analyze() {
     success: 23,
   };
 
+  const [isOpen, setIsOpen] = useState(false);
+  const [modalVariant, setModalVariant] = useState<"selectFile" | "processing">(
+    "selectFile",
+  );
+  const openModal = (variant: "selectFile" | "processing") => {
+    setModalVariant(variant);
+    setIsOpen(true);
+  };
+
+  const closeModal = () => setIsOpen(false);
+
+  const onProceedProcessing = () => {
+    openModal("processing");
+  };
+
   return (
     <section className="mx-auto w-full max-w-[110rem] px-[1rem]">
       <TitleBar title="sfacweb-01" />
       <div className="grid grid-cols-[16rem_1fr] gap-7">
-        <Button>선택한 파일 검사</Button>
+        <Button onClick={() => openModal("selectFile")}>
+          선택한 파일 검사
+        </Button>
         <div className="rounded-lg border border-line-default p-5">
           <ProgressBar value={0.7} className="mb-5" />
           <div className="flex gap-7">
@@ -46,6 +65,12 @@ export default function Analyze() {
           <CodeViewer type="toBe" />
         </div>
       </div>
+      <Modal
+        variant={modalVariant}
+        isOpen={isOpen}
+        onClose={closeModal}
+        onProceed={onProceedProcessing}
+      />
     </section>
   );
 }

--- a/src/app/vulnerability-db/page.tsx
+++ b/src/app/vulnerability-db/page.tsx
@@ -20,7 +20,9 @@ import { Label } from "@/components/ui/Label";
 import Pagination from "@/components/ui/Pagination";
 import { Ranking } from "@/components/ui/Ranking";
 import { cn } from "@/lib/utils";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import clsx from "clsx";
+import Modal from "@/components/ui/Modal";
 
 const vulnerabilityDBDatas = [
   {
@@ -71,12 +73,29 @@ export default function VulnerabilityDBPage() {
   const startPage = (currentGroup - 1) * pagesPerGroup + 1;
   const endPage = Math.min(startPage + pagesPerGroup - 1, totalPages);
 
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const openLoginModal = () => setIsLoginModalOpen(true);
+  const closeLoginModal = () => setIsLoginModalOpen(false);
+
+  useEffect(() => {
+    const checkLoginStatus = async () => {
+      const userLoggedIn = false; // 추후에 서버로 받아오도록 변경
+      setIsLoggedIn(userLoggedIn);
+
+      if (!userLoggedIn) {
+        openLoginModal();
+      }
+    };
+    checkLoginStatus();
+  }, []);
+
   return (
     <div className="mx-auto mb-[1.188rem] mt-[1.688rem] flex w-[82.063rem] flex-col gap-[4.75rem]">
       <CardContainer />
       <div className="flex gap-[6.375rem]">
         {/* 취약점 DB */}
-        <VulnerabilityDB />
+        <VulnerabilityDB isLoggedIn={isLoggedIn} />
         {/* 실시간 Topic */}
         <RealTimeTopic />
       </div>
@@ -89,6 +108,11 @@ export default function VulnerabilityDBPage() {
           setCurrentPage={setCurrentPage}
         />
       </div>
+      <Modal
+        variant="login"
+        isOpen={isLoginModalOpen}
+        onClose={closeLoginModal}
+      />
     </div>
   );
 }
@@ -175,9 +199,13 @@ function CardContainer() {
   );
 }
 
-function VulnerabilityDB() {
+function VulnerabilityDB({ isLoggedIn }: { isLoggedIn: boolean }) {
   return (
-    <section>
+    <section
+      className={clsx("relative", {
+        "blur-sm filter": !isLoggedIn,
+      })}
+    >
       <h2 className="text-2xl font-semibold leading-[1.816rem] tracking-[-0.01em]">
         취약점 DB
       </h2>

--- a/src/components/ui/CustomerService.tsx
+++ b/src/components/ui/CustomerService.tsx
@@ -1,8 +1,30 @@
+"use client";
 import { cn } from "@/lib/utils";
 import { Input } from "./Input";
 import { TextArea } from "./TextArea";
+import { useState } from "react";
+import Modal from "./Modal";
 
 export default function CustomerService({ className }: { className?: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [modalVariant, setModalVariant] = useState<
+    "selectFile" | "processing" | "login" | "inquirySubmitted"
+  >("inquirySubmitted");
+
+  const openModal = (
+    variant: "selectFile" | "processing" | "login" | "inquirySubmitted",
+  ) => {
+    setModalVariant(variant);
+    setIsOpen(true);
+  };
+
+  const closeModal = () => setIsOpen(false);
+
+  const onClickSubmit = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    openModal("inquirySubmitted");
+  };
+
   return (
     <section
       className={cn(
@@ -87,10 +109,15 @@ export default function CustomerService({ className }: { className?: string }) {
             className="mt-2 h-56"
           />
         </div>
-        <button className="rounded-lg bg-primary-500 py-[0.813rem] text-lg font-semibold text-white">
+        <button
+          type="button"
+          className="rounded-lg bg-primary-500 py-[0.813rem] text-lg font-semibold text-white"
+          onClick={() => openModal("inquirySubmitted")}
+        >
           문의 보내기
         </button>
       </form>
+      <Modal variant={modalVariant} isOpen={isOpen} onClose={closeModal} />
     </section>
   );
 }

--- a/src/components/ui/Icons.tsx
+++ b/src/components/ui/Icons.tsx
@@ -384,11 +384,16 @@ export function IconPlus({ className, ...props }: React.ComponentProps<"svg">) {
   );
 }
 
-export function IconBug({ className, ...props }: React.ComponentProps<"svg">) {
+export function IconBug({
+  className,
+  width = "191",
+  height = "196",
+  ...props
+}: React.ComponentProps<"svg"> & { width?: string; height?: string }) {
   return (
     <svg
-      width="191"
-      height="196"
+      width={width}
+      height={height}
       viewBox="0 0 191 196"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -3,25 +3,33 @@ import { IconBug, IconRoundedDoc } from "./Icons";
 import Button from "./Button";
 
 type ModalProps = {
-  variant: "selectFile" | "processing" | "login";
+  variant: "selectFile" | "processing" | "login" | "inquirySubmitted";
   isOpen: boolean;
   onClose: () => void;
+  onProceed?: () => void;
 };
 
-export default function Modal({ variant, isOpen, onClose }: ModalProps) {
+export default function Modal({
+  variant,
+  isOpen,
+  onClose,
+  onProceed,
+}: ModalProps) {
   if (!isOpen) return null;
 
   //공통 스타일
-  const baseModalStyles = "relative bg-white rounded-[1.25rem]";
+  const baseModalStyles = "relative bg-white rounded-[1.25rem] ";
 
   //variant별 스타일 적용
   const modalStyles = clsx({
-    "w-[42.875rem] h-[29.875rem] p-[3rem] gap-[2.5rem]":
+    "w-[42.875rem] h-[29.875rem] p-[3rem] gap-[2.5rem] top-[10rem] ":
       variant === "selectFile",
-    "w-[26.688rem] h-[24.063rem] top-[13.188rem] left-[3.5rem] p-[3rem] gap-[3.313rem] ":
+    "w-[26.688rem] h-[24.063rem] top-[10rem] p-[3rem] gap-[3.313rem] ":
       variant === "processing",
-    "w-[21.313rem] h-[13.125rem] top-[15.375rem] left-[3.438rem] p-[2.5rem_3.75rem] gap-[2rem] rounded-[1.25rem] shadow-[0_0_1.55rem_rgba(0,0,0,0.25)]":
+    "w-[21.313rem] h-[13.125rem] top-[15.375rem] p-[2.5rem_3.75rem] gap-[2rem] rounded-[1.25rem] shadow-[0_0_1.55rem_rgba(0,0,0,0.25)]":
       variant === "login",
+    "w-[61.563rem] h-[21.563rem] p-[3.75rem] gap-[3.5rem] rounded-[2.5rem] ":
+      variant === "inquirySubmitted",
   });
 
   //variant별 콘텐츠 렌더링
@@ -68,7 +76,10 @@ export default function Modal({ variant, isOpen, onClose }: ModalProps) {
                 닫기
               </button>
               {/* 임시버튼 */}
-              <button className="h-[3.313rem] w-[8.5rem] gap-[0.625rem] rounded-xl bg-primary-500 p-[0.75rem_1.5rem] text-white">
+              <button
+                className="h-[3.313rem] w-[8.5rem] gap-[0.625rem] rounded-xl bg-primary-500 p-[0.75rem_1.5rem] text-white"
+                onClick={onProceed}
+              >
                 검사하기
               </button>
             </div>
@@ -100,9 +111,27 @@ export default function Modal({ variant, isOpen, onClose }: ModalProps) {
                 자세한 정보를 보고싶다면?
               </h2>
               {/* 임시버튼 */}
-              <button className="h-[4.625rem] w-[7.438rem] rounded-[999px] border-2 border-purple-600 p-[1rem_1.5rem] text-[1.75rem] font-light leading-[2.118rem] tracking-[-0.01em] text-purple-600">
+              <button className="h-[4.625rem] w-[7.438rem] rounded-[999px] border-2 border-primary-500 p-[1rem_1.5rem] text-[1.75rem] font-light leading-[2.118rem] tracking-[-0.01em] text-primary-500">
                 Login
               </button>
+            </div>
+          </>
+        );
+      case "inquirySubmitted":
+        return (
+          <>
+            <div className="flex-col-center-center">
+              <div className="flex-col-center-center h-[7.063rem] w-[41.8rem] gap-[1.438rem]">
+                <h1 className="text-[2.25rem] font-bold leading-[3.375rem] tracking-[-0.01em]">
+                  문의를 보냈어요!
+                </h1>
+                <p className="text-[1.5rem] font-medium leading-[2.25rem] tracking-[-0.011em] text-[#8F8F8F]">
+                  문의를 성공적으로 전송했어요. 빠른 시일 내에 답변해드릴게요.
+                </p>
+              </div>
+              <Button className="mt-14 h-14 w-[20.938rem] gap-[0.625rem] text-[1.25rem] tracking-[-0.011em]">
+                홈으로 가기
+              </Button>
             </div>
           </>
         );
@@ -114,8 +143,10 @@ export default function Modal({ variant, isOpen, onClose }: ModalProps) {
   return (
     <div
       className={clsx("fixed inset-0 z-50 flex items-center justify-center", {
-        "bg-black bg-opacity-50": variant === "processing",
-        "bg-transparent": variant !== "processing",
+        "bg-black bg-opacity-50":
+          variant === "processing" || variant === "inquirySubmitted",
+        "bg-transparent":
+          variant !== "processing" && variant != "inquirySubmitted",
       })}
     >
       <div className={`${baseModalStyles} ${modalStyles}`}>

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,126 @@
+import clsx from "clsx";
+import { IconBug, IconRoundedDoc } from "./Icons";
+import Button from "./Button";
+
+type ModalProps = {
+  variant: "selectFile" | "processing" | "login";
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export default function Modal({ variant, isOpen, onClose }: ModalProps) {
+  if (!isOpen) return null;
+
+  //공통 스타일
+  const baseModalStyles = "relative bg-white rounded-[1.25rem]";
+
+  //variant별 스타일 적용
+  const modalStyles = clsx({
+    "w-[42.875rem] h-[29.875rem] p-[3rem] gap-[2.5rem]":
+      variant === "selectFile",
+    "w-[26.688rem] h-[24.063rem] top-[13.188rem] left-[3.5rem] p-[3rem] gap-[3.313rem] ":
+      variant === "processing",
+    "w-[21.313rem] h-[13.125rem] top-[15.375rem] left-[3.438rem] p-[2.5rem_3.75rem] gap-[2rem] rounded-[1.25rem] shadow-[0_0_1.55rem_rgba(0,0,0,0.25)]":
+      variant === "login",
+  });
+
+  //variant별 콘텐츠 렌더링
+  const renderContent = () => {
+    switch (variant) {
+      case "selectFile":
+        return (
+          <>
+            <h2 className="mb-10 text-center text-2xl font-normal leading-[1.816rem] tracking-[-0.01em]">
+              선택된 파일을 검사하시겠습니까?
+            </h2>
+            {[...Array(5)].map((_, ulIndex) => (
+              <ul
+                key={ulIndex}
+                className={clsx(
+                  "h-11 w-[36.875rem] border border-b border-[#bcbcbc] p-[0.625rem]",
+                  {
+                    "rounded-t-lg": ulIndex === 0,
+                    "rounded-b-lg": ulIndex === 4,
+                  },
+                )}
+              >
+                <li className="flex items-center justify-between">
+                  <div className="flex items-center">
+                    <IconRoundedDoc className="mr-[0.625rem]" />
+
+                    <div className="font-medium">file name</div>
+                  </div>
+                  <div className="text-xs font-normal leading-[0.907rem] tracking-[-0.01em] text-[#9E9E9E]">
+                    file sub title
+                  </div>
+
+                  <div className="text-xs leading-[0.907rem] tracking-[-0.01em] text-[#9E9E9E]">
+                    4 months ago
+                  </div>
+                </li>
+              </ul>
+            ))}
+            <div className="mt-10 flex justify-center space-x-4">
+              <button
+                className="flex h-[3.313rem] w-[5.75rem] items-center justify-center gap-[0.625rem] rounded-xl border border-[#6100FF] p-[0.75rem_1.5rem] text-[#6100FF]"
+                onClick={onClose}
+              >
+                닫기
+              </button>
+              {/* 임시버튼 */}
+              <button className="h-[3.313rem] w-[8.5rem] gap-[0.625rem] rounded-xl bg-primary-500 p-[0.75rem_1.5rem] text-white">
+                검사하기
+              </button>
+            </div>
+          </>
+        );
+      case "processing":
+        return (
+          <>
+            <div className="flex h-full flex-col items-center justify-center gap-[3.313rem] text-center">
+              <IconBug width="106" height="109" />
+              <div className="h-[7.938rem] w-[22.688rem] gap-[2.375rem]">
+                <h2 className="mb-[2.375rem] text-[1.5rem] font-semibold leading-[1.816rem] tracking-[-0.01em] text-gray-dark">
+                  소스코드 취약점 분석중
+                </h2>
+                <p className="h-[3.75rem] text-center text-[1.25rem] font-medium leading-[1.875rem] tracking-[-0.01em] text-gray-default">
+                  AI 플로디텍터가 문제를 분석중입니다.
+                  <br />
+                  코드가 많을수록 처리시간이 길어집니다.
+                </p>
+              </div>
+            </div>
+          </>
+        );
+      case "login":
+        return (
+          <>
+            <div className="flex w-[15rem] flex-col items-center justify-center text-center">
+              <h2 className="mb-8 h-6 w-[15rem] text-[1.25rem] font-semibold leading-[1.512rem] tracking-[-0.01em]">
+                자세한 정보를 보고싶다면?
+              </h2>
+              {/* 임시버튼 */}
+              <button className="h-[4.625rem] w-[7.438rem] rounded-[999px] border-2 border-purple-600 p-[1rem_1.5rem] text-[1.75rem] font-light leading-[2.118rem] tracking-[-0.01em] text-purple-600">
+                Login
+              </button>
+            </div>
+          </>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div
+      className={clsx("fixed inset-0 z-50 flex items-center justify-center", {
+        "bg-black bg-opacity-50": variant === "processing",
+        "bg-transparent": variant !== "processing",
+      })}
+    >
+      <div className={`${baseModalStyles} ${modalStyles}`}>
+        {renderContent()}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경사항 및 이유
- 모달을 사용하는 페이지 수정하였습니다.
- IconBug의 크기를 수정할 수 있도록 리팩토링 하였습니다.

## 작업 내역
- 공통 모달 컴포넌트를 추가했습니다.
- 사용 예시입니다.
`<Modal
        variant={modalVariant}
        isOpen={isOpen} 
        onClose={closeModal} 
        onProceed={onProceedProcessing}  // selectFile 모달에서 processing모달 전달할때만 사용
      />
`

### Modal variant
- selectFile : analyze 페이지에서 사용하는 선택파일 모달
![image](https://github.com/user-attachments/assets/fbadac7c-9512-4c1f-a050-9852946b890a)

- processing :  analyze 페이지에서 사용하는 아이콘 모달.
selectFile 모달의 검사하기 버튼 클릭시 processing 모달 오픈
![image](https://github.com/user-attachments/assets/a6370ace-388b-4ebf-8069-b37187a118b3)

- login : 취약점 DB페이지에서 비로그인일 시 뜨는 모달
![image](https://github.com/user-attachments/assets/91abcab1-dffe-487f-95c8-0432c6631b03)

- inquirySubmitted : 랜딩페이지에서 문의보내기 버튼 클릭 시 뜨는 모달
![image](https://github.com/user-attachments/assets/0b160edd-389f-4c96-ada8-c53ec8101180)


## PR 특이 사항

