### PR TITLE
Feat : 랜딩 페이지 Section 4 구현

### DIFF
--- a/src/components/landing/Section4.tsx
+++ b/src/components/landing/Section4.tsx
@@ -12,7 +12,7 @@ export default function Section4() {
           </p>
         </article>
         <article className="relative w-full overflow-x-hidden">
-          <div className="relative ml-[-10.604rem] grid min-h-[35rem] w-[120%] grid-cols-6 gap-x-12 overflow-x-hidden whitespace-pre-wrap">
+          <div className="relative ml-[-10.604rem] grid min-h-[35rem] w-[120%] grid-cols-6 gap-x-12 whitespace-pre-wrap">
             <ServiceCard variant="security" />
             <ServiceCard variant="critical" />
             <ServiceCard variant="realtime" />

--- a/src/components/landing/Section4.tsx
+++ b/src/components/landing/Section4.tsx
@@ -1,4 +1,4 @@
-import ServiceCard from "../ui/ServiceCard";
+import ServiceCard from "./ServiceCard";
 
 export default function Section4() {
   return (

--- a/src/components/landing/Section4.tsx
+++ b/src/components/landing/Section4.tsx
@@ -1,0 +1,27 @@
+import ServiceCard from "../ui/ServiceCard";
+
+export default function Section4() {
+  return (
+    <>
+      {/* max-h-screen */}
+      <section className="flex min-h-dvh w-full flex-col gap-y-[7.5rem] bg-primary-500">
+        <article className="pt-[8.898rem]">
+          <p className="flex-col-center-center space-y-3 text-[3.75rem] font-bold leading-[4.538rem] -tracking-[0.011em] text-white">
+            <span>안전과 보호를 우선으로 하는</span>
+            <span>프로세스를 제공합니다.</span>
+          </p>
+        </article>
+        <article className="relative w-full overflow-x-hidden">
+          <div className="relative ml-[-10.604rem] grid min-h-[35rem] w-[120%] grid-cols-6 gap-x-12 overflow-x-hidden whitespace-pre-wrap">
+            <ServiceCard variant="security" />
+            <ServiceCard variant="critical" />
+            <ServiceCard variant="realtime" />
+            <ServiceCard variant="privacy" />
+            <ServiceCard variant="efficiency" />
+            <ServiceCard variant="quick" />
+          </div>
+        </article>
+      </section>
+    </>
+  );
+}

--- a/src/components/landing/ServiceCard.tsx
+++ b/src/components/landing/ServiceCard.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
-import { Card, CardContent, CardSubTitle } from "./Card";
-import { ServiceLabel, ServiceLabelProps } from "./Label";
+import { Card, CardContent, CardSubTitle } from "../ui/Card";
+import { ServiceLabel, ServiceLabelProps } from "../ui/Label";
 
 export type ServiceVariants = {
   variant:

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -13,7 +13,7 @@ const cardVariants = cva("relative flex flex-col", {
       article: "justify-between border border-[#c3c3c3]",
       image: "justify-end hover:bg-opacity-70",
       service:
-        "justify-center items-center shadow-[0_5rem_3.75rem_-2.5rem_rgba(0,0,0,0.25)]",
+        "justify-center items-center bg-white before:content-[''] before:absolute before:inset-0 before:shadow-[0_5rem_3.75rem_-2.5rem_rgba(0,0,0,0.25)] before:rounded-[2.5rem] before:z-30",
     },
     size: {
       default:

--- a/src/components/ui/ServiceCard.tsx
+++ b/src/components/ui/ServiceCard.tsx
@@ -1,0 +1,88 @@
+import Image from "next/image";
+import { Card, CardContent, CardSubTitle } from "./Card";
+import { ServiceLabel, ServiceLabelProps } from "./Label";
+
+export type ServiceVariants = {
+  variant:
+    | "security"
+    | "critical"
+    | "realtime"
+    | "privacy"
+    | "efficiency"
+    | "quick";
+};
+
+export type ServiceInfo = {
+  color: ServiceLabelProps["color"];
+  title: string;
+  descriptions: [string, string];
+  image: string;
+};
+
+const serviceCardDetails: Record<ServiceVariants["variant"], ServiceInfo> = {
+  security: {
+    color: "pink",
+    title: "보안 강화",
+    descriptions: ["보안 취약점 사전 식별 후 해결", "소프트웨어 보안성 강화"],
+    image: "/images/lockedWithKey.png",
+  },
+  critical: {
+    color: "green",
+    title: "미션 크리티컬한 개발에 적합",
+    descriptions: ["미션 크리티컬한 개발 특별 제작", "안전한 솔루션 제공"],
+    image: "/images/gear.png",
+  },
+  realtime: {
+    color: "purple",
+    title: "실시간 보안 업데이트",
+    descriptions: [
+      "최신 보안 동향 및 취약점 정보 실시간 제공",
+      "개발자 보안 강화를 도움",
+    ],
+    image: "/images/lockedWithPen.png",
+  },
+  privacy: {
+    color: "blue",
+    title: "사용자 데이터 보호",
+    descriptions: [
+      "데이터 무단 액세스 및 정보 유출 방지",
+      "개인 정보 안전하게 보호",
+    ],
+    image: "/images/stopHand.png",
+  },
+  efficiency: {
+    color: "yellow",
+    title: "효율적인 개발",
+    descriptions: ["보안 취약점 자동 분석 후 수정", "개발 집중 및 생산성 향상"],
+    image: "/images/circularArrows.png",
+  },
+  quick: {
+    color: "red",
+    title: "신속한 대응과 수정",
+    descriptions: ["발견된 취약점 대응 및 수정", "안전한 소프트웨어 개발 가능"],
+    image: "/images/checkMark.png",
+  },
+};
+
+export default function ServiceCard({
+  variant,
+  className,
+}: ServiceVariants & { className?: string }) {
+  const { color, title, descriptions, image } = serviceCardDetails[variant];
+
+  return (
+    <Card variant="service" size="service" className={className}>
+      <ServiceLabel color={color}>{title}</ServiceLabel>
+      <CardContent variant="emoji" bgColor="transparent">
+        <Image src={image} alt="key" width={120} height={180} />
+      </CardContent>
+      <div className="flex-col-center-center gap-y-1">
+        {descriptions.map((description, index) => (
+          <CardSubTitle color="#606060" key={index}>
+            {description}
+          </CardSubTitle>
+        ))}
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## 변경사항 및 이유
- 랜딩페이지의 4 섹션 구현
- ServiceCard 컴포넌트 생성

## 작업 내역
- 애니메이션이 예상되는 화면이나, 우선은 정적인 화면만 구현했습니다.
- max-h-screen (100vh)을 적용하지 않았습니다. (현재 height가 100vh보다 큰 상황)

## PR 특이 사항
- 구현 화면

![image](https://github.com/user-attachments/assets/633c4936-5c37-4e22-a62b-830c42ddb84f)
