### PR TITLE
Fix : 빌드 에러 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@sparticuz/chromium": "^127.0.0",
     "@tanstack/react-query": "^5.51.23",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@sparticuz/chromium':
+        specifier: ^127.0.0
+        version: 127.0.0
       '@tanstack/react-query':
         specifier: ^5.51.23
         version: 5.51.23(react@18.3.1)
@@ -244,6 +247,10 @@ packages:
 
   '@rushstack/eslint-patch@1.10.4':
     resolution: {integrity: sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==}
+
+  '@sparticuz/chromium@127.0.0':
+    resolution: {integrity: sha512-3YdElfXb6kqcFtlgaArNZohhZ1gWAiWg5kPYIZbaoHFau7dHZvbYg3EEjeE30bYi6cfOnB8wVpluuasF8Y3QyQ==}
+    engines: {node: '>= 16'}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -901,6 +908,15 @@ packages:
 
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+
+  follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -2162,6 +2178,13 @@ snapshots:
 
   '@rushstack/eslint-patch@1.10.4': {}
 
+  '@sparticuz/chromium@127.0.0':
+    dependencies:
+      follow-redirects: 1.15.6
+      tar-fs: 3.0.6
+    transitivePeerDependencies:
+      - debug
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.5':
@@ -3070,6 +3093,8 @@ snapshots:
       rimraf: 3.0.2
 
   flatted@3.3.1: {}
+
+  follow-redirects@1.15.6: {}
 
   for-each@0.3.3:
     dependencies:

--- a/src/app/api/authenticate/route.ts
+++ b/src/app/api/authenticate/route.ts
@@ -1,33 +1,6 @@
-import { LLAMA_AUTH_URL, LLAMA_PASSWORD, LLAMA_USERNAME } from "@/lib/const";
+import { getAPItoken } from "@/lib/api/llama3";
 import { handleError } from "@/lib/helpers";
 import { NextResponse } from "next/server";
-
-export async function getAPItoken() {
-  if (!LLAMA_USERNAME || !LLAMA_PASSWORD) {
-    throw new Error("환경 변수 USERNAME 또는 PASSWORD가 설정되지 않았습니다.");
-  }
-
-  const authResponse = await fetch(LLAMA_AUTH_URL!, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: new URLSearchParams({
-      grant_type: "password",
-      username: LLAMA_USERNAME,
-      password: LLAMA_PASSWORD,
-      scope: "",
-    }),
-  });
-
-  if (!authResponse.ok) {
-    const errorData = await authResponse.json();
-    throw new Error(`인증 실패: ${JSON.stringify(errorData)}`);
-  }
-
-  const authData = await authResponse.json();
-  return authData.access_token;
-}
 
 export async function POST() {
   try {

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -1,6 +1,6 @@
+import { getAPItoken } from "@/lib/api/llama3";
 import { LLAMA_API_URL } from "@/lib/const";
 import { NextRequest, NextResponse } from "next/server";
-import { getAPItoken } from "../authenticate/route";
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/web-crawling/cisa/route.ts
+++ b/src/app/api/web-crawling/cisa/route.ts
@@ -1,43 +1,28 @@
-import os from "os";
+import { handleError } from "@/lib/helpers";
+import Chromium from "@sparticuz/chromium";
+import { NextResponse } from "next/server";
 import puppeteer from "puppeteer-core";
 
-/** 운영체제별로 Chrome 실행 파일 경로 찾기 */
-export const getChromeExecutablePath = () => {
-  const platform = os.platform();
-  if (platform === "win32") {
-    // Windows
-    return "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
-  } else if (platform === "darwin") {
-    // macOS
-    return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
-  } else if (platform === "linux") {
-    // Linux
-    return "/usr/bin/google-chrome";
-  } else if (platform === "freebsd") {
-    // FreeBSD
-    return "/usr/local/bin/google-chrome";
-  } else {
-    throw new Error(`지원하지 않는 운영체제: ${platform}`);
-    // 문제가 발생할 경우 대안책: chrome-launcher 라이브러리 (Chrome 실행 파일 경로 자동 설정 가능)
-  }
-};
-
 export async function GET() {
-  const executablePath = getChromeExecutablePath();
+  try {
+    // Puppeteer로 브라우저 실행
+    const browser = await puppeteer.launch({
+      executablePath: await Chromium.executablePath(),
+      headless: true,
+    });
 
-  // Puppeteer로 브라우저 실행
-  const browser = await puppeteer.launch({
-    executablePath,
-    headless: true,
-  });
+    const page = await browser.newPage();
 
-  const page = await browser.newPage();
+    // 크롤링할 사이트 URL로 이동
+    await page.goto("");
 
-  // 크롤링할 사이트 URL로 이동
-  await page.goto("");
+    // 크롤링 코드 작성
 
-  // 크롤링 코드 작성
+    // 브라우저 종료
+    await browser.close();
 
-  // 브라우저 종료
-  await browser.close();
+    return NextResponse.json({ message: "크롤링 완료" });
+  } catch (error) {
+    return handleError(error);
+  }
 }

--- a/src/app/api/web-crawling/cnnvd/route.ts
+++ b/src/app/api/web-crawling/cnnvd/route.ts
@@ -1,22 +1,28 @@
+import { handleError } from "@/lib/helpers";
+import Chromium from "@sparticuz/chromium";
+import { NextResponse } from "next/server";
 import puppeteer from "puppeteer-core";
-import { getChromeExecutablePath } from "../cisa/route";
 
 export async function GET() {
-  const executablePath = getChromeExecutablePath();
+  try {
+    // Puppeteer로 브라우저 실행
+    const browser = await puppeteer.launch({
+      executablePath: await Chromium.executablePath(),
+      headless: true,
+    });
 
-  // Puppeteer로 브라우저 실행
-  const browser = await puppeteer.launch({
-    executablePath,
-    headless: true,
-  });
+    const page = await browser.newPage();
 
-  const page = await browser.newPage();
+    // 크롤링할 사이트 URL로 이동
+    await page.goto("");
 
-  // 크롤링할 사이트 URL로 이동
-  await page.goto("");
+    // 크롤링 코드 작성
 
-  // 크롤링 코드 작성
+    // 브라우저 종료
+    await browser.close();
 
-  // 브라우저 종료
-  await browser.close();
+    return NextResponse.json({ message: "크롤링 완료" });
+  } catch (error) {
+    return handleError(error);
+  }
 }

--- a/src/app/api/web-crawling/github-database/route.ts
+++ b/src/app/api/web-crawling/github-database/route.ts
@@ -1,22 +1,28 @@
+import { handleError } from "@/lib/helpers";
+import Chromium from "@sparticuz/chromium";
+import { NextResponse } from "next/server";
 import puppeteer from "puppeteer-core";
-import { getChromeExecutablePath } from "../cisa/route";
 
 export async function GET() {
-  const executablePath = getChromeExecutablePath();
+  try {
+    // Puppeteer로 브라우저 실행
+    const browser = await puppeteer.launch({
+      executablePath: await Chromium.executablePath(),
+      headless: true,
+    });
 
-  // Puppeteer로 브라우저 실행
-  const browser = await puppeteer.launch({
-    executablePath,
-    headless: true,
-  });
+    const page = await browser.newPage();
 
-  const page = await browser.newPage();
+    // 크롤링할 사이트 URL로 이동
+    await page.goto("");
 
-  // 크롤링할 사이트 URL로 이동
-  await page.goto("");
+    // 크롤링 코드 작성
 
-  // 크롤링 코드 작성
+    // 브라우저 종료
+    await browser.close();
 
-  // 브라우저 종료
-  await browser.close();
+    return NextResponse.json({ message: "크롤링 완료" });
+  } catch (error) {
+    return handleError(error);
+  }
 }

--- a/src/components/vulnerability-db/ArticleDetail.tsx
+++ b/src/components/vulnerability-db/ArticleDetail.tsx
@@ -40,7 +40,7 @@ export default function ArticleDetail({
       </div>
       <div className="mx-auto mb-[3.75rem] h-[43.75rem] w-[82.125rem] gap-[0.625rem] border-b border-b-gray-500 pb-[3.75rem]">
         <div className="max-h-[43.75rem] overflow-y-auto px-[0.938rem] text-2xl font-normal leading-[2.25rem] tracking-[-0.01em]">
-          {content.split("\n").map((paragraph, idx) => (
+          {content?.split("\n").map((paragraph, idx) => (
             <p key={idx} className="mb-4 text-justify">
               {paragraph}
             </p>

--- a/src/lib/api/llama3.ts
+++ b/src/lib/api/llama3.ts
@@ -1,0 +1,28 @@
+import { LLAMA_AUTH_URL, LLAMA_PASSWORD, LLAMA_USERNAME } from "@/lib/const";
+
+export async function getAPItoken() {
+  if (!LLAMA_USERNAME || !LLAMA_PASSWORD) {
+    throw new Error("환경 변수 USERNAME 또는 PASSWORD가 설정되지 않았습니다.");
+  }
+
+  const authResponse = await fetch(LLAMA_AUTH_URL!, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "password",
+      username: LLAMA_USERNAME,
+      password: LLAMA_PASSWORD,
+      scope: "",
+    }),
+  });
+
+  if (!authResponse.ok) {
+    const errorData = await authResponse.json();
+    throw new Error(`인증 실패: ${JSON.stringify(errorData)}`);
+  }
+
+  const authData = await authResponse.json();
+  return authData.access_token;
+}


### PR DESCRIPTION
## 변경사항 및 이유
+ 프로젝트를 build 했을 때 아래와 같은 에러가 발생해서 해결했습니다.


![image (1)](https://github.com/user-attachments/assets/ba47f240-22d3-488c-b579-dc779f68ac01)

![image](https://github.com/user-attachments/assets/d91d3991-c92c-4fea-b818-5e6d5c774f67)

![image (2)](https://github.com/user-attachments/assets/80be4733-cb47-49ba-88cb-12b0d6d5f9bd)




## 작업 내역

+ route 파일 내에는 POST와 같은 HTTP 메서드만 존재하도록 수정하였습니다.
+ `api/authenticate/route.ts`에서 사용하던 getAPItoken 함수를 `lib > api > llama3.ts`로 이동했습니다.
+ `api/web-crawling/route.ts`에서 사용하던 getChromeExecutablePath 함수는 삭제하고,
    `@sparticuz/chromium` 라이브러리를 설치하여 크롬 실행 파일 경로를 찾도록 수정했습니다.
+ `ArticleDetail.tsx`의 content 변수에 옵셔널 체이닝을 추가하여 undefined를 해결했습니다.

## PR 특이 사항

+ 완료 화면입니다!👍

![완료](https://github.com/user-attachments/assets/45d5f913-e5b9-46c4-8ffa-8a4472367537)
