### PR TITLE
Modify : ArticleDetail 페이지 CNNVD 데이터 랜더링

### DIFF
--- a/src/app/api/web-crawling/cnnvd/route.ts
+++ b/src/app/api/web-crawling/cnnvd/route.ts
@@ -130,7 +130,7 @@ export async function GET() {
 
     const content = await page.evaluate(() => {
       const paragraphs = document.querySelectorAll(
-        "div.detail-content > p.MsoNormal, div.detail-content > pre, div.detail-content > font, div.detail-content > p.\\32,  div.detail-content > h2, div.detail-content > p.MsoNormalCxSpFirst",
+        "div.detail-content > p.MsoNormal, div.detail-content > pre, div.detail-content > font, div.detail-content > p.\\32,  div.detail-content > p, div.detail-content > h2, div.detail-content > p.MsoNormalCxSpFirst",
       );
       let description = "";
       let introduction = "";

--- a/src/components/vulnerability-db/ArticleDetail.tsx
+++ b/src/components/vulnerability-db/ArticleDetail.tsx
@@ -1,5 +1,5 @@
 import { VulDBPost } from "@/types/post";
-import { isCertCCContentType } from "@/types/typeGuards";
+import { isCertCCContentType, isCnnvdContentType } from "@/types/typeGuards";
 import Link from "next/link";
 import { ArticleDetailHeader } from "./ArticleDetailHeader";
 
@@ -57,15 +57,40 @@ function CertCCContent({ post }: { post: VulDBPost }) {
 }
 
 function CNNVDContent({ post }: { post: VulDBPost }) {
+  if (!isCnnvdContentType(post.content)) return null;
+
+  const { description, introduction, vulnDetail, remediation } = post.content;
+
+  const renderSection = (
+    title: string,
+    content: { id: string; text: string }[] | undefined,
+  ) => {
+    if (!content || content.length === 0) return null;
+
+    return (
+      <section className="text-2xl font-medium text-gray-dark">
+        <h2 className="mb-2">{title}</h2>
+        {content.map((item) => (
+          <p key={item.id} className="leading-10">
+            {item.text}
+          </p>
+        ))}
+      </section>
+    );
+  };
+
   return (
-    <div className="mx-auto mb-[3.75rem] h-[43.75rem] w-[82.125rem] gap-[0.625rem] border-b border-b-gray-500 pb-[3.75rem]">
-      <div className="max-h-[43.75rem] overflow-y-auto px-[0.938rem] text-2xl font-normal leading-[2.25rem] tracking-[-0.01em]">
-        {/* {content?.split("\n").map((paragraph, idx) => (
-      <p key={idx} className="mb-4 text-justify">
-        {paragraph}
-      </p>
-    ))} */}
-      </div>
+    <div className="mb-14 flex w-[80.25rem] flex-col gap-14">
+      {renderSection("", [{ id: "description", text: description.translated }])}
+      {renderSection("1. 취약점 소개", [
+        { id: "introduction", text: introduction.translated },
+      ])}
+      {renderSection("2. 취약점 세부정보", [
+        { id: "vulnDetail", text: vulnDetail.translated },
+      ])}
+      {renderSection("3. 수리 제안", [
+        { id: "remediation", text: remediation.translated },
+      ])}
     </div>
   );
 }


### PR DESCRIPTION
## 변경사항 및 이유
- 크롤링할 태그를 추가했습니다. 

## 작업 내역
- ArticleDetail에 CNNVD 데이터 랜더링할 수 있도록 CNNVDContent함수를 추가했습니다.

## PR 특이 사항
- CNNVD 웹페이지는 디테일 페이지마다 크롤링 할 content의 태그명이 다른 이슈가 있습니다. 누락된 데이터를 통해 추가로 크롤링할 태그를 파악하고 있습니다. 
- 빌드 통과했습니다.