### PR TITLE
Feat : 취약점 DB 게시글 핀 기능 구현

### DIFF
--- a/src/app/(posts)/vuldb/items/[id]/page.tsx
+++ b/src/app/(posts)/vuldb/items/[id]/page.tsx
@@ -1,6 +1,7 @@
+import { auth } from "@/auth";
 import ArticleDetail from "@/components/vulnerability-db/ArticleDetail";
 import SimilarInfoPosts from "@/components/vulnerability-db/SimilarInfoPosts";
-import { getAllPosts, getPostById, increasePostViews } from "@/lib/api/posts";
+import { getAllPosts, getPostById } from "@/lib/api/posts";
 import { redirectIfNotLoggedIn } from "@/lib/redirect";
 import { VulDBPost } from "@/types/post";
 
@@ -10,16 +11,19 @@ export default async function VulnerabilityDBDetailPage({
   params: { id: string };
 }) {
   await redirectIfNotLoggedIn("/vuldb/items");
+  const session = await auth();
 
   const postId = params.id;
   const post = (await getPostById(postId)) as VulDBPost;
   const posts = await getAllPosts();
 
+  const userId = session?.user.userId;
+
   return (
     <div className="mb-[8.596rem] mt-[2.063rem] flex flex-col items-center gap-[3.75rem]">
-      <ArticleDetail post={post} />
+      <ArticleDetail post={post} userId={userId} />
       {/* <VulnerabilityGrid /> */}
-      <SimilarInfoPosts posts={posts} postId={postId} />
+      <SimilarInfoPosts posts={posts} postId={postId} userId={userId} />
     </div>
   );
 }

--- a/src/components/vulnerability-db/ArticleDetail.tsx
+++ b/src/components/vulnerability-db/ArticleDetail.tsx
@@ -70,10 +70,16 @@ function CNNVDContent({ post }: { post: VulDBPost }) {
   );
 }
 
-export default function ArticleDetail({ post }: { post: VulDBPost }) {
+export default function ArticleDetail({
+  post,
+  userId,
+}: {
+  post: VulDBPost;
+  userId: string;
+}) {
   return (
     <>
-      <ArticleDetailHeader post={post} />
+      <ArticleDetailHeader post={post} userId={userId} />
       {post.source === "CERT/CC" && <CertCCContent post={post} />}
       {post.source === "CNNVD" && <CNNVDContent post={post} />}
     </>

--- a/src/components/vulnerability-db/ArticleDetailHeader.tsx
+++ b/src/components/vulnerability-db/ArticleDetailHeader.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { addPinnedPostToUser } from "@/lib/api/users";
 import { formatTimestampAsDateTime } from "@/lib/utils";
 import { useVulDBPostsStore } from "@/stores/useVulDBPostsStore";
-import { VulDBPost } from "@/types/post";
+import { VulDBPinnedInfo, VulDBPost } from "@/types/post";
 import { Timestamp } from "firebase/firestore";
 import { useLayoutEffect, useState } from "react";
 import { IconPin, IconShare } from "../ui/Icons";
@@ -14,7 +15,13 @@ export function LabelSkeleton() {
   );
 }
 
-export function ArticleDetailHeader({ post }: { post: VulDBPost }) {
+export function ArticleDetailHeader({
+  post,
+  userId,
+}: {
+  post: VulDBPost;
+  userId: string;
+}) {
   const haveUpdatedAt = post.source_updated_at;
   const { vulDBPostsWithChip } = useVulDBPostsStore();
   const [isMounted, setIsMounted] = useState(false);
@@ -28,6 +35,8 @@ export function ArticleDetailHeader({ post }: { post: VulDBPost }) {
     return foundPost ? foundPost.chip : "";
   };
   const chip = getChipById(post.id);
+
+  const pinnedInfo: VulDBPinnedInfo = { userId, postId: post.id };
 
   return (
     <section className="w-[82.125rem] border-b border-b-line-default p-[1.75rem_0_3.75rem_0]">
@@ -56,7 +65,11 @@ export function ArticleDetailHeader({ post }: { post: VulDBPost }) {
           </p>
         </div>
         <div className="flex gap-[1.625rem]">
-          <IconPin />
+          <IconPin
+            onClick={async () => {
+              await addPinnedPostToUser(pinnedInfo);
+            }}
+          />
           <IconShare />
         </div>
       </div>

--- a/src/components/vulnerability-db/SimilarInfoPosts.tsx
+++ b/src/components/vulnerability-db/SimilarInfoPosts.tsx
@@ -9,9 +9,10 @@ import {
 } from "@/components/ui/Card";
 import { IconPin, IconShare } from "@/components/ui/Icons";
 import { Label } from "@/components/ui/Label";
+import { addPinnedPostToUser } from "@/lib/api/users";
 import { formatTimestampAsDaysAgo } from "@/lib/utils";
 import { useVulDBPostsStore } from "@/stores/useVulDBPostsStore";
-import { VulDBPost, VulDBPostWithChip } from "@/types/post";
+import { VulDBPinnedInfo, VulDBPost, VulDBPostWithChip } from "@/types/post";
 import { isCertCCContentType } from "@/types/typeGuards";
 import Link from "next/link";
 import { useLayoutEffect, useState } from "react";
@@ -41,8 +42,16 @@ function SkeletonCard() {
   );
 }
 
-function SimilarInfoPostCard({ post }: { post: VulDBPostWithChip }) {
+function SimilarInfoPostCard({
+  post,
+  userId,
+}: {
+  post: VulDBPostWithChip;
+  userId: string;
+}) {
   if (!post) return null;
+
+  const pinnedInfo: VulDBPinnedInfo = { userId, postId: post.id };
 
   return (
     <Card
@@ -76,7 +85,13 @@ function SimilarInfoPostCard({ post }: { post: VulDBPostWithChip }) {
       {/* CNNVD 데이터가 db에 들어오면 추가 예정 */}
       <CardFooter>
         <div className="inline-flex gap-4">
-          <IconPin />
+          <IconPin
+            onClick={async (event) => {
+              event.stopPropagation();
+              event.preventDefault();
+              await addPinnedPostToUser(pinnedInfo);
+            }}
+          />
           <IconShare />
         </div>
         <CardSubTitle className="font-medium">
@@ -92,9 +107,11 @@ function SimilarInfoPostCard({ post }: { post: VulDBPostWithChip }) {
 export default function SimilarInfoPosts({
   posts,
   postId,
+  userId,
 }: {
   posts: VulDBPost[];
   postId: string;
+  userId: string;
 }) {
   const { vulDBPostsWithChip } = useVulDBPostsStore();
   const [isMounted, setIsMounted] = useState(false);
@@ -127,7 +144,7 @@ export default function SimilarInfoPosts({
               return (
                 <li key={post.id}>
                   <Link href={`/vuldb/items/${post.id}`}>
-                    <SimilarInfoPostCard post={post} />
+                    <SimilarInfoPostCard post={post} userId={userId} />
                   </Link>
                 </li>
               );

--- a/src/components/vulnerability-db/VulDBDashboard.tsx
+++ b/src/components/vulnerability-db/VulDBDashboard.tsx
@@ -71,7 +71,9 @@ function VulDBAuthGate({ posts }: { posts: VulDBPostWithChip[] }) {
     );
   }
 
-  return <VulDBList posts={posts} />;
+  const userId = session.user.userId;
+
+  return <VulDBList posts={posts} userId={userId} />;
 }
 
 function VulDB({

--- a/src/components/vulnerability-db/VulDBList.tsx
+++ b/src/components/vulnerability-db/VulDBList.tsx
@@ -8,12 +8,13 @@ import {
 } from "@/components/ui/Card";
 import { IconExternalLink, IconPin } from "@/components/ui/Icons";
 import { Label } from "@/components/ui/Label";
+import { increasePostViews } from "@/lib/api/posts";
+import { addPinnedPostToUser } from "@/lib/api/users";
 import { formatTimestampAsDaysAgo } from "@/lib/utils";
-import { VulDBPostWithChip } from "@/types/post";
+import { VulDBPinnedInfo, VulDBPostWithChip } from "@/types/post";
 import { isCertCCContentType, isCnnvdContentType } from "@/types/typeGuards";
 import Link from "next/link";
 import { LabelSkeleton } from "./ArticleDetailHeader";
-import { increasePostViews } from "@/lib/api/posts";
 
 export function VulDBListCardSkeleton() {
   return (
@@ -44,8 +45,16 @@ export function VulDBListCardSkeleton() {
   );
 }
 
-function VulDBListCard({ post }: { post: VulDBPostWithChip }) {
+function VulDBListCard({
+  post,
+  userId,
+}: {
+  post: VulDBPostWithChip;
+  userId: string;
+}) {
   if (!post) return null;
+
+  const pinnedInfo: VulDBPinnedInfo = { userId, postId: post.id };
 
   const daysAgo = formatTimestampAsDaysAgo(post.created_at);
   return (
@@ -105,7 +114,15 @@ function VulDBListCard({ post }: { post: VulDBPostWithChip }) {
       </CardContent>
       <CardFooter>
         <div className="flex gap-3">
-          <IconPin width={28} height={28} />
+          <IconPin
+            width={28}
+            height={28}
+            onClick={async (event) => {
+              event.stopPropagation();
+              event.preventDefault();
+              await addPinnedPostToUser(pinnedInfo);
+            }}
+          />
           <IconExternalLink />
         </div>
         <CardSubTitle color="#A2A2A2" className="font-medium">
@@ -116,7 +133,13 @@ function VulDBListCard({ post }: { post: VulDBPostWithChip }) {
   );
 }
 
-export default function VulDBList({ posts }: { posts: VulDBPostWithChip[] }) {
+export default function VulDBList({
+  posts,
+  userId,
+}: {
+  posts: VulDBPostWithChip[];
+  userId?: string;
+}) {
   if (!posts || posts.length === 0) {
     return <p className="text-gray-500">데이터가 없습니다.</p>; // 임시
   }
@@ -132,7 +155,7 @@ export default function VulDBList({ posts }: { posts: VulDBPostWithChip[] }) {
             }}
           >
             <Link href={`/vuldb/items/${post.id}`}>
-              <VulDBListCard post={post} />
+              <VulDBListCard post={post} userId={userId as string} />
             </Link>
           </li>
         );

--- a/src/types/post.d.ts
+++ b/src/types/post.d.ts
@@ -66,3 +66,8 @@ export type VulDBPost = {
 };
 
 export type VulDBPostWithChip = VulDBPost & { chip: "hot" | "new" | "" };
+
+export type VulDBPinnedInfo = {
+  userId: string;
+  postId: string;
+};


### PR DESCRIPTION
## 변경사항 및 이유
- 제목과 같습니다.

## 작업 내역
- 총 세 곳에서 핀 기능(스크랩)이 작동합니다.

```
1. 취약점 DB 메인 페이지에서 게시글 핀 
2. 취약점 DB 상세 페이지에서 게시글 상단 부분의 핀 
3. 취약점 DB 상세 페이지에서 비슷한 정보글 핀
```

- 취약점 DB 메인 페이지: 사용자의 로그인 여부를 확인할 때 사용하는 session에서 userId를 활용했습니다.
- 취약점 DB 상세 페이지: auth 함수를 사용해서 session에서 userId를 뽑아냈습니다.

- 쿼리를 통해 userId와 일치하는 사용자가 있는지 확인 후 결과가 존재한다면 첫 번째 문서를 가져옵니다.
- Firestore의 `updateDoc()`을 사용해서 `pinnedPosts` 필드에 게시글의 id(`postId`: `string`)를 추가하였고, `arrayUnion()`을 사용하여 배열에 중복값이 저장되지 않도록 구현했습니다.

