### PR TITLE
Feat : VulDBList의 공유 기능 추가

### DIFF
--- a/src/app/(posts)/vuldb/items/[id]/page.tsx
+++ b/src/app/(posts)/vuldb/items/[id]/page.tsx
@@ -21,7 +21,7 @@ export default async function VulnerabilityDBDetailPage({
   const userId = session?.user.userId;
 
   return (
-    <div className="relative mx-auto mb-[8.596rem] mt-[2.063rem] flex w-[120rem] flex-col items-center gap-[3.75rem] px-[1rem]">
+    <div className="relative mx-auto mb-[8.596rem] mt-[2.063rem] flex max-w-[120rem] flex-col items-center gap-[3.75rem] px-[1rem]">
       <ArticleDetail post={post} userId={userId} />
       {/* <VulnerabilityGrid /> */}
       <SimilarInfoPosts posts={posts} postId={postId} userId={userId} />

--- a/src/components/vulnerability-db/VulDBList.tsx
+++ b/src/components/vulnerability-db/VulDBList.tsx
@@ -6,7 +6,7 @@ import {
   CardSubTitle,
   CardTitle,
 } from "@/components/ui/Card";
-import { IconExternalLink } from "@/components/ui/Icons";
+import { IconExternalLink, IconShare } from "@/components/ui/Icons";
 import { Label } from "@/components/ui/Label";
 import { increasePostViews } from "@/lib/api/posts";
 import { addPinnedPostToUser } from "@/lib/api/users";
@@ -58,6 +58,20 @@ function VulDBListCard({
   const pinnedInfo: VulDBPinnedInfo = { userId, postId: post.id };
 
   const daysAgo = formatTimestampAsDaysAgo(post.created_at);
+
+  const postUrl = `${window.location.origin}/vuldb/items/${post.id}`;
+
+  const handleShareClick = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+    try {
+      await navigator.clipboard.writeText(postUrl);
+      alert("URL이 복사되었습니다!");
+    } catch (error) {
+      console.error("URL 복사 실패:", error);
+    }
+  };
+
   return (
     <Card
       variant="article"
@@ -116,7 +130,7 @@ function VulDBListCard({
       <CardFooter>
         <div className="flex gap-3">
           <VulDBPin pinnedInfo={pinnedInfo} />
-          <IconExternalLink />
+          <IconShare onClick={handleShareClick} />
         </div>
         <CardSubTitle color="#A2A2A2" className="font-medium">
           {daysAgo || "날짜를 알 수 없음"}


### PR DESCRIPTION
## 변경사항 및 이유
- 카드리스트의 share 아이콘을 추가하였습니다. 
-  <IconExternalLink /> 삭제  <IconShare onClick={handleShareClick} /> 추가
- 카드리스트의 공유 기능 추가하였습니다. 
- 카드임을 감안하여 공유 시 alert로 공유 완료 메세지가 뜹니다.

## 작업 내역
- 카드리스트 부분 공유 기능 구현

## PR 특이 사항
- 빌드 확인 했습니다.
![image](https://github.com/user-attachments/assets/92217f9f-1278-4817-97c2-8e1d9fb0a6ea)
