### PR TITLE
Modify : 마이 라이브러리 (레포 리스트) 페이지 ux 개선

### DIFF
--- a/src/app/(member)/me/settings/page.tsx
+++ b/src/app/(member)/me/settings/page.tsx
@@ -32,8 +32,13 @@ export default async function SettingsPage() {
           <div className="flex w-full flex-col gap-y-12 text-2xl -tracking-[0.01em]">
             <h2 className="font-semibold">알림</h2>
             <div className="flex-between-center w-full">
-              <span className="font-normal">이메일로 알림 받기</span>
-              <Switch />
+              <p className="flex gap-x-3">
+                <span className="font-normal">이메일로 알림 받기</span>
+                <span className="text-gray-default">
+                  (준비 중인 기능입니다.)
+                </span>
+              </p>
+              <Switch variant="disabled" />
             </div>
           </div>
         </section>

--- a/src/app/(member)/repos/page.tsx
+++ b/src/app/(member)/repos/page.tsx
@@ -52,12 +52,12 @@ export default async function ReposPage() {
 
       <div className="flex flex-col gap-y-7">
         <section className="flex flex-col gap-y-20">
-          <div className="flex-between-center h-fit gap-4 rounded-[2.625rem] bg-neutral-5 p-8">
-            <Profile />
-            <Link href="/me">
+          <Link href="/me" className="pointer-events-none">
+            <div className="flex-between-center pointer-events-auto h-fit gap-4 rounded-[2.625rem] bg-neutral-5 p-8">
+              <Profile />
               <IconCaretLeft className="fill-[rgba(52, 51, 48, 1)] size-12 rotate-180" />
-            </Link>
-          </div>
+            </div>
+          </Link>
         </section>
 
         <section className="flex-between-center gap-x-[1.313rem]">

--- a/src/app/(member)/repos/page.tsx
+++ b/src/app/(member)/repos/page.tsx
@@ -53,7 +53,7 @@ export default async function ReposPage() {
       <div className="flex flex-col gap-y-7">
         <section className="flex flex-col gap-y-20">
           <Link href="/me" className="pointer-events-none">
-            <div className="flex-between-center pointer-events-auto h-fit gap-4 rounded-[2.625rem] bg-neutral-5 p-8">
+            <div className="flex-between-center pointer-events-auto h-fit gap-4 rounded-[2.625rem] bg-neutral-5 p-8 hover:bg-[#ededed]">
               <Profile />
               <IconCaretLeft className="fill-[rgba(52, 51, 48, 1)] size-12 rotate-180" />
             </div>

--- a/src/components/me/Repo.tsx
+++ b/src/components/me/Repo.tsx
@@ -1,6 +1,5 @@
 import { cn, formatDatetimeToYYMMDD } from "@/lib/utils";
 import { RepoListData } from "@/types/repo";
-import { SessionProvider } from "next-auth/react";
 import Link from "next/link";
 import { memo } from "react";
 import Button from "../ui/Button";
@@ -58,30 +57,28 @@ function Repo({
   return (
     <Card key={id} className="group relative">
       <CardHeader>
-        <SessionProvider>
-          {detectedStatus !== "notChecked" ? (
-            <>
-              <div className="flex-between-center">
-                {labelStatus[detectedStatus] && (
-                  <Label variant={labelStatus[detectedStatus]}>
-                    {detectedStatus === "done" ? "검사완료" : "검사중"}
-                  </Label>
-                )}
-                <RepoBookmark repo={repositoryName} isBookmarked={favorite} />
-              </div>
-              <CardTitle size="big" className="leading-[2.45rem]">
-                {repositoryName}
-              </CardTitle>
-            </>
-          ) : (
+        {detectedStatus !== "notChecked" ? (
+          <>
             <div className="flex-between-center">
-              <CardTitle size="big" className="leading-[2.45rem]">
-                {repositoryName}
-              </CardTitle>
+              {labelStatus[detectedStatus] && (
+                <Label variant={labelStatus[detectedStatus]}>
+                  {detectedStatus === "done" ? "검사완료" : "검사중"}
+                </Label>
+              )}
               <RepoBookmark repo={repositoryName} isBookmarked={favorite} />
             </div>
-          )}
-        </SessionProvider>
+            <CardTitle size="big" className="leading-[2.45rem]">
+              {repositoryName}
+            </CardTitle>
+          </>
+        ) : (
+          <div className="flex-between-center">
+            <CardTitle size="big" className="leading-[2.45rem]">
+              {repositoryName}
+            </CardTitle>
+            <RepoBookmark repo={repositoryName} isBookmarked={favorite} />
+          </div>
+        )}
       </CardHeader>
       <CardFooter>
         <Link href={`/repos/${repositoryName}`} className="basis-[9.153rem]">

--- a/src/components/me/RepoBookmark.tsx
+++ b/src/components/me/RepoBookmark.tsx
@@ -3,7 +3,6 @@
 import { memo, useCallback, useState } from "react";
 import { IconStar } from "../ui/Icons";
 import { cn } from "@/lib/utils";
-import { useSession } from "next-auth/react";
 
 function RepoBookmark({
   repo,
@@ -12,33 +11,33 @@ function RepoBookmark({
   repo: string;
   isBookmarked: boolean;
 }) {
-  const { data: session } = useSession();
+  // const { data: session } = useSession();
   const [isSelected, setIsSelected] = useState(isBookmarked);
 
-  const onToggleFavorite = useCallback(async () => {
-    try {
-      const res = await fetch("/api/repos", {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: session?.user?.username,
-          repoName: repo,
-          favorite: !isSelected,
-        }),
-      });
+  // const onToggleFavorite = useCallback(async () => {
+  //   try {
+  //     const res = await fetch("/api/repos", {
+  //       method: "PATCH",
+  //       headers: {
+  //         "Content-Type": "application/json",
+  //       },
+  //       body: JSON.stringify({
+  //         username: session?.user?.username,
+  //         repoName: repo,
+  //         favorite: !isSelected,
+  //       }),
+  //     });
 
-      if (!res.ok) {
-        const errorData = await res.json();
-        throw new Error(errorData.error || "Failed to save results.");
-      }
+  //     if (!res.ok) {
+  //       const errorData = await res.json();
+  //       throw new Error(errorData.error || "Failed to save results.");
+  //     }
 
-      setIsSelected(!isSelected);
-    } catch (err) {
-      console.error("Error adding results:", err);
-    }
-  }, [isSelected, repo, session]);
+  //     setIsSelected(!isSelected);
+  //   } catch (err) {
+  //     console.error("Error adding results:", err);
+  //   }
+  // }, [isSelected, repo, session]);
 
   return (
     <div
@@ -48,7 +47,7 @@ function RepoBookmark({
           ? "opacity-100"
           : "border-[0.083rem] border-primary-100 bg-white opacity-0 transition-opacity group-hover:opacity-100",
       )}
-      onClick={onToggleFavorite}
+      // onClick={onToggleFavorite}
     >
       {isSelected ? (
         <IconStar className="size-8 fill-primary-200 stroke-primary-200" />

--- a/src/components/me/RepoList.tsx
+++ b/src/components/me/RepoList.tsx
@@ -50,10 +50,6 @@ export default function RepoList({
   const filteredAndSortedRepos = useMemo(() => {
     let result = [...repos];
 
-    if (filterByBookmarked) {
-      result = result.filter((repo) => repo.favorite);
-    }
-
     // 검사 여부 필터링
     if (filterType && filterType !== "-1") {
       result = result.filter((repo) => repo.detectedStatus === filterType);
@@ -110,7 +106,7 @@ export default function RepoList({
       </div>
 
       {initialRepos.length === 0 ? (
-        <div className="flex-col-center-center 1150:h-[30.75rem] w-full gap-y-[0.625rem]">
+        <div className="flex-col-center-center w-full gap-y-[0.625rem] 1150:h-[30.75rem]">
           <p className="text-[2rem] font-semibold leading-[2.8rem] tracking-[0.015em] text-gray-dark">
             Github에 레포지토리가 존재하지 않습니다.
           </p>
@@ -119,13 +115,13 @@ export default function RepoList({
           </p>
         </div>
       ) : currentRepos.length == 0 ? (
-        <div className="flex-col-center-center 1150:h-[30.75rem] w-full gap-y-[0.625rem]">
+        <div className="flex-col-center-center w-full gap-y-[0.625rem] 1150:h-[30.75rem]">
           <p className="text-[2rem] font-semibold leading-[2.8rem] tracking-[0.015em] text-gray-dark">
             조건에 맞는 레포지토리가 없습니다.
           </p>
         </div>
       ) : (
-        <div className="flex-between-center 1150:grid-cols-4 relative grid grid-cols-3 grid-rows-3 gap-x-6 gap-y-12">
+        <div className="flex-between-center relative grid grid-cols-3 grid-rows-3 gap-x-6 gap-y-12 1150:grid-cols-4">
           {currentRepos.map((repo) => (
             <Repo key={repo.repositoryName} username={username} {...repo} />
           ))}

--- a/src/components/me/RepoList.tsx
+++ b/src/components/me/RepoList.tsx
@@ -108,12 +108,29 @@ export default function RepoList({
           <Dropdown type="sort" onSelectFilter={setSortType} />
         </div>
       </div>
-      <div className="flex-between-center relative grid grid-cols-3 grid-rows-3 gap-x-6 gap-y-12 1150:grid-cols-4">
-        {currentRepos.map((repo) => (
-          <Repo key={repo.repositoryName} username={username} {...repo} />
-        ))}
-      </div>
 
+      {initialRepos.length === 0 ? (
+        <div className="flex-col-center-center 1150:h-[30.75rem] w-full gap-y-[0.625rem]">
+          <p className="text-[2rem] font-semibold leading-[2.8rem] tracking-[0.015em] text-gray-dark">
+            Github에 레포지토리가 존재하지 않습니다.
+          </p>
+          <p className="flex-col-center-center text-2xl font-normal leading-[2.1rem] text-gray-default">
+            <span>새로운 프로젝트를 시작해보세요.</span>
+          </p>
+        </div>
+      ) : currentRepos.length == 0 ? (
+        <div className="flex-col-center-center 1150:h-[30.75rem] w-full gap-y-[0.625rem]">
+          <p className="text-[2rem] font-semibold leading-[2.8rem] tracking-[0.015em] text-gray-dark">
+            조건에 맞는 레포지토리가 없습니다.
+          </p>
+        </div>
+      ) : (
+        <div className="flex-between-center 1150:grid-cols-4 relative grid grid-cols-3 grid-rows-3 gap-x-6 gap-y-12">
+          {currentRepos.map((repo) => (
+            <Repo key={repo.repositoryName} username={username} {...repo} />
+          ))}
+        </div>
+      )}
       <div className="flex-center-center w-full">
         <Pagination
           currentPage={currPage}

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -1,11 +1,21 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { Dispatch, SetStateAction, useState } from "react";
+import { forwardRef, useRef, useState } from "react";
 import { IconCaretDown, IconCheck } from "./Icons";
+import useOutsideClick from "@/hooks/useOutsideClick";
 
 export type DropdownProps = React.HTMLAttributes<HTMLDivElement> & {
   type: "type" | "sort";
+  onSelectFilter: React.Dispatch<React.SetStateAction<string>>;
+};
+
+type DropdownMenuProps = {
+  options: Option[];
+  selectedIndex: number;
+  setSelectedIndex: React.Dispatch<React.SetStateAction<number>>;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onChange: React.Dispatch<React.SetStateAction<string>>;
 };
 
 export type Option = { id: string; name: string; value: string };
@@ -32,65 +42,58 @@ const getOptions = (type: string): Option[] => {
   }
 };
 
-function DropdownMenu({
-  options,
-  selectedIndex,
-  setSelectedIndex,
-  setIsOpen,
-  onChange,
-}: {
-  options: Option[];
-  selectedIndex: number;
-  setSelectedIndex: React.Dispatch<React.SetStateAction<number>>;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  onChange: (value: string) => void;
-}) {
-  const onClickOption = (index: number) => {
-    const newIndex = index === selectedIndex ? -1 : index;
-    setSelectedIndex(newIndex);
-    setIsOpen(false); // close dropdown
-    onChange(newIndex === -1 ? "-1" : options[index].value);
-  };
-
-  return (
-    <ul
-      className={cn(
-        "absolute top-[3.25rem] z-10 w-full overflow-hidden rounded-lg bg-white shadow-[0_0.125rem_1rem_0_rgba(0,0,0,0.25)]",
-      )}
-      role="menu"
-      aria-label="menu"
-    >
-      {options?.map(({ id, name, value }, index) => (
-        <li
-          key={id}
-          className={cn(
-            "flex-center-center h-[2.438rem] w-full bg-white px-[0.6rem] py-[0.469rem] transition-all duration-300 first:rounded-t-lg last:rounded-b-lg",
-            selectedIndex === index
-              ? "cursor-default justify-between bg-purple-dark"
-              : "hover:bg-purple-light",
-            name.length > 3 && "px-[0.1rem]",
-          )}
-          onClick={() => onClickOption(index)}
-          value={value}
-          role="menu item"
-          aria-label="menu item"
-        >
-          {selectedIndex === index && <IconCheck width={20} height={20} />}
-          {name}
-        </li>
-      ))}
-    </ul>
-  );
-}
+const DropdownMenu = forwardRef<HTMLUListElement, DropdownMenuProps>(
+  ({ options, selectedIndex, setSelectedIndex, setIsOpen, onChange }, ref) => {
+    const onClickOption = (index: number) => {
+      const newIndex = index === selectedIndex ? -1 : index;
+      setSelectedIndex(newIndex);
+      setIsOpen(false); // close dropdown
+      onChange(newIndex === -1 ? "-1" : options[index].value);
+    };
+    return (
+      <ul
+        className={cn(
+          "absolute top-[3.25rem] z-10 w-full overflow-hidden rounded-lg bg-white shadow-[0_0.125rem_1rem_0_rgba(0,0,0,0.25)]",
+        )}
+        role="menu"
+        aria-label="menu"
+        ref={ref}
+      >
+        {options?.map(({ id, name, value }, index) => (
+          <li
+            key={id}
+            className={cn(
+              "flex-center-center h-[2.438rem] w-full bg-white px-[0.6rem] py-[0.469rem] transition-all duration-300 first:rounded-t-lg last:rounded-b-lg",
+              selectedIndex === index
+                ? "cursor-default justify-between bg-purple-dark"
+                : "hover:bg-purple-light",
+              name.length > 3 && "px-[0.1rem]",
+            )}
+            onClick={() => onClickOption(index)}
+            value={value}
+            role="menu-item"
+            aria-label="menu item"
+          >
+            {selectedIndex === index && <IconCheck width={20} height={20} />}
+            {name}
+          </li>
+        ))}
+      </ul>
+    );
+  },
+);
+DropdownMenu.displayName = "DropdownMenu";
 
 export default function Dropdown({
   type,
-  className,
   onSelectFilter,
+  className,
   ...props
-}: DropdownProps & { onSelectFilter: Dispatch<SetStateAction<string>> }) {
+}: DropdownProps) {
+  const menuRef = useRef<HTMLUListElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
+  useOutsideClick(menuRef, () => setIsOpen(false));
 
   return (
     <div
@@ -116,6 +119,7 @@ export default function Dropdown({
           setSelectedIndex={setSelectedIndex}
           setIsOpen={setIsOpen}
           onChange={onSelectFilter}
+          ref={menuRef}
         />
       )}
     </div>

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -25,9 +25,15 @@ const Pagination: React.FC<PaginationProps> = ({
   );
 
   return (
-    <div className={cn("flex items-center gap-[0.625rem]", className)}>
+    <div
+      className={cn(
+        "grid grid-flow-col grid-cols-12 gap-[0.625rem]",
+        `grid-cols-${pages.length + 2}`,
+        className,
+      )}
+    >
       {/* Render Previous Page button only if there's a previous page */}
-      {currentPage > 1 && (
+      {currentPage > 1 ? (
         <button
           onClick={() => setCurrentPage(currentPage - 1)}
           className="text-center text-[1rem] font-normal leading-6 tracking-[-0.011em] text-gray-dark focus:outline-none"
@@ -35,6 +41,8 @@ const Pagination: React.FC<PaginationProps> = ({
         >
           <IconCaretLeft className="fill-default" />
         </button>
+      ) : (
+        currentPage < totalPages && <div></div>
       )}
       {/* Page Numbers */}
       {pages.map((page) => (
@@ -52,7 +60,7 @@ const Pagination: React.FC<PaginationProps> = ({
         </button>
       ))}
       {/* Render Next Page button only if there's a next page */}
-      {currentPage < totalPages && (
+      {currentPage < totalPages ? (
         <button
           onClick={() => setCurrentPage(currentPage + 1)}
           className="text-center text-[1rem] font-normal leading-6 tracking-[-0.011em] focus:outline-none"
@@ -60,6 +68,8 @@ const Pagination: React.FC<PaginationProps> = ({
         >
           <IconCaretLeft className="fill-default rotate-180" />
         </button>
+      ) : (
+        currentPage > 1 && <div className="w-8"></div>
       )}
     </div>
   );

--- a/src/components/ui/Pagination.tsx
+++ b/src/components/ui/Pagination.tsx
@@ -42,7 +42,7 @@ const Pagination: React.FC<PaginationProps> = ({
           <IconCaretLeft className="fill-default" />
         </button>
       ) : (
-        currentPage < totalPages && <div></div>
+        currentPage < totalPages && <div className="w-8"></div>
       )}
       {/* Page Numbers */}
       {pages.map((page) => (

--- a/src/components/ui/Switch.tsx
+++ b/src/components/ui/Switch.tsx
@@ -2,6 +2,21 @@
 
 import { useState } from "react";
 import { cn } from "@/lib/utils";
+import { cva, VariantProps } from "class-variance-authority";
+import { IconClose } from "./Icons";
+
+const switchVariants = cva("flex h-8 w-14 items-center rounded-[6.25rem]", {
+  variants: {
+    variant: {
+      default: "cursor-pointer",
+      disabled:
+        "border-2 border-primary-200 bg-purple-light opacity-50 cursor-not-allowed",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
 
 function SwitchThumb({ isActive }: { isActive: boolean }) {
   return (
@@ -25,10 +40,25 @@ function SwitchThumb({ isActive }: { isActive: boolean }) {
   );
 }
 
+function SwitchDisabledThumb() {
+  return (
+    <div
+      className={cn(
+        "relative h-6 w-6 rounded-[50%] transition-transform duration-300 active:scale-110 disabled:cursor-not-allowed disabled:bg-primary-200 disabled:bg-opacity-50",
+        "flex-center-center ml-[0.125rem] bg-[#1D1B20]",
+      )}
+    >
+      <IconClose className="h-[1rem] w-[1rem] fill-purple-light opacity-50" />
+    </div>
+  );
+}
+
 export default function Switch({
+  variant,
   className,
   ...props
-}: React.HTMLAttributes<HTMLButtonElement>) {
+}: React.HTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof switchVariants>) {
   const [isActive, setIsActive] = useState(false);
 
   const trackStyles = {
@@ -39,14 +69,20 @@ export default function Switch({
   return (
     <button
       className={cn(
-        "flex h-8 w-14 cursor-pointer items-center rounded-[6.25rem]",
-        isActive ? trackStyles["active"] : trackStyles["inactive"],
+        switchVariants({ variant }),
+        variant !== "disabled" &&
+          (isActive ? trackStyles["active"] : trackStyles["inactive"]),
         className,
       )}
-      onClick={() => setIsActive(!isActive)}
+      onClick={() => variant !== "disabled" && setIsActive(!isActive)}
+      disabled={variant === "disabled"}
       {...props}
     >
-      <SwitchThumb isActive={isActive} />
+      {variant === "disabled" ? (
+        <SwitchDisabledThumb />
+      ) : (
+        <SwitchThumb isActive={isActive} />
+      )}
     </button>
   );
 }

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,19 @@
+import { RefObject, useEffect } from "react";
+
+const useOutsideClick = (ref: RefObject<HTMLElement>, callback: () => void) => {
+  useEffect(() => {
+    const listener = (event: MouseEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      callback();
+    };
+
+    document.addEventListener("mousedown", listener);
+    return () => {
+      document.removeEventListener("mousedown", listener);
+    };
+  }, [ref, callback]);
+};
+
+export default useOutsideClick;


### PR DESCRIPTION
## 변경사항 및 이유
- 마이 라이브러리 (레포 리스트) 페이지 내 기능 동작이 사용자의 기대와 어긋나는 부분이 있어 어색한 부분을 개선함
- 클라이언트 단에서의 너무 많은 session 요청

## 작업 내역
- 프로필 페이지로 연결되는 링크 범위 확장
- 로그인 사용자의 레파지토리가 없는 경우, 필터를 적용했을 때 부합하는 조건이 없는 경우에 대한 문구 추가
- Dropdown 메뉴가 열린 상태에서 바깥 영역 클릭 시 닫힘 처리
  - 커스텀 훅 추가하여 이용함
- 페이지네이션 너비 고정 (css의 grid layout으로 보다 세련되게 처리하는 방법이 있는데, 실패해서 결국 js의 힘을 빌렸습니다..)
- RepoBookmark 컴포넌트로 유저 정보를 넘겨주기 위해 SessionProvider로 감쌌으나 session 요청이 너무 많이 발생하고 있어 잠정적 주석 처리함 -> 서버의 유저 정보를 클라이언트 단으로 동기화시켜 전역으로 관리할 예정

## PR 특이 사항
- [x] 빌드 테스트 통과했습니다
