### PR TITLE
Fix : Alert 및 검사 결과 상태 출력 버그 해결

### DIFF
--- a/src/app/(member)/repos/[repo_name]/page.tsx
+++ b/src/app/(member)/repos/[repo_name]/page.tsx
@@ -1,5 +1,5 @@
 import { auth } from "@/auth";
-import CodeViewer from "@/components/analyze/CodeViewer";
+import CodeContainer from "@/components/analyze/CodeContainer";
 import FileListServer from "@/components/analyze/FileListServer";
 import RunInspectButton from "@/components/analyze/RunInspectButton";
 import {
@@ -38,7 +38,7 @@ export default async function RepoPage({
           </Status>
           <FileListServer repo={repo} username={username} />
         </div>
-        <CodeViewer username={username} repo={repo} />
+        <CodeContainer username={username} repo={repo} />
       </div>
     </section>
   );

--- a/src/app/api/repos/route.ts
+++ b/src/app/api/repos/route.ts
@@ -68,17 +68,17 @@ export async function PATCH(req: NextRequest) {
       });
     }
 
-    if (!favorite) {
+    if (favorite) {
       // 북마크 여부 저장
       repoData.repos[repoIndex].favorite = favorite;
     }
 
-    if (!clickedAt) {
+    if (clickedAt) {
       // 클릭한 시간 저장
       repoData.repos[repoIndex].clickedAt = clickedAt;
     }
 
-    if (!detectedStatus) {
+    if (detectedStatus) {
       // 검사 상태 저장
       repoData.repos[repoIndex].detectedStatus = detectedStatus;
     }

--- a/src/components/analyze/CodeContainer.tsx
+++ b/src/components/analyze/CodeContainer.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useDetectedModeStore } from "@/stores/useDetectedModeStore";
+import { useFileProcessStore } from "@/stores/useFileProcessStore";
+import { useFileViewerStore } from "@/stores/useFileViewerStore";
+import { use, useEffect, useMemo, useState } from "react";
+import { Alert } from "../ui/Alert";
+import CodeResultsList from "./CodeResultsList";
+import CodeViewer from "./CodeViewer";
+
+type CodeContainerProps = {
+  username: string;
+  repo: string;
+};
+
+export default function CodeContainer({ username, repo }: CodeContainerProps) {
+  // 현재 파일의 검사 여부
+  const currentFile = useFileViewerStore((state) => state.currentFile);
+  const getFileStatus = useFileProcessStore((state) => state.getFileStatus);
+  const status = currentFile ? getFileStatus(currentFile) : null;
+
+  // 현재 파일의 검사 결과
+  const getMode = useDetectedModeStore((state) => state.getMode);
+  const setMode = useDetectedModeStore((state) => state.setMode);
+  const mode = currentFile ? getMode(currentFile) : null;
+  const results = useFileProcessStore((state) => state.fileDetectedResults);
+
+  const [isAlertOpen, setIsAlertOpen] = useState(true);
+
+  useEffect(() => {
+    if (currentFile) {
+      if (!status) {
+        setIsAlertOpen(false);
+      }
+      setIsAlertOpen(true);
+    }
+  }, [currentFile, status, setIsAlertOpen]);
+
+  useEffect(() => {
+    if (currentFile) {
+      setMode(currentFile, "undetected");
+    }
+  }, [currentFile, results, setMode]);
+
+  return (
+    <section className={cn("relative w-full")}>
+      {/* 코드 뷰어 */}
+      <CodeViewer
+        username={username}
+        repo={repo}
+        className={
+          results && mode === "detected" && status === "success"
+            ? "h-full max-h-[34.688rem]"
+            : ""
+        }
+      />
+      {status && (
+        <Alert
+          username={username}
+          status={status}
+          isOpen={isAlertOpen}
+          onClose={() => setIsAlertOpen(false)}
+        />
+      )}
+
+      {/* 검사 결과 */}
+      {results && mode === "detected" && status === "success" && (
+        <CodeResultsList results={results} />
+      )}
+    </section>
+  );
+}

--- a/src/components/analyze/CodeContainer.tsx
+++ b/src/components/analyze/CodeContainer.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { useDetectedModeStore } from "@/stores/useDetectedModeStore";
 import { useFileProcessStore } from "@/stores/useFileProcessStore";
 import { useFileViewerStore } from "@/stores/useFileViewerStore";
-import { use, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Alert } from "../ui/Alert";
 import CodeResultsList from "./CodeResultsList";
 import CodeViewer from "./CodeViewer";

--- a/src/components/analyze/CodeContainer.tsx
+++ b/src/components/analyze/CodeContainer.tsx
@@ -17,6 +17,7 @@ type CodeContainerProps = {
 export default function CodeContainer({ username, repo }: CodeContainerProps) {
   // 현재 파일의 검사 여부
   const currentFile = useFileViewerStore((state) => state.currentFile);
+  const fileStatuses = useFileProcessStore((state) => state.fileStatuses);
   const getFileStatus = useFileProcessStore((state) => state.getFileStatus);
   const status = currentFile ? getFileStatus(currentFile) : null;
 
@@ -27,6 +28,10 @@ export default function CodeContainer({ username, repo }: CodeContainerProps) {
   const results = useFileProcessStore((state) => state.fileDetectedResults);
 
   const [isAlertOpen, setIsAlertOpen] = useState(true);
+
+  useEffect(() => {
+    console.log("status", fileStatuses.values().next().value);
+  }, [fileStatuses]);
 
   useEffect(() => {
     if (currentFile) {

--- a/src/components/analyze/CodeResultsList.tsx
+++ b/src/components/analyze/CodeResultsList.tsx
@@ -1,27 +1,18 @@
 import { FileResultFailProps, FileResultProps } from "@/types/file";
-import { Dispatch, SetStateAction } from "react";
-import ResultInfoBox from "./ResultInfoBox";
+import CodeResultsListItem from "./CodeResultsListItem";
 
-type ResultListProps = {
+type CodeResultsListProps = {
   results: FileResultProps[] | FileResultFailProps;
-  setDetectedLines: Dispatch<SetStateAction<number[]>>;
 };
 
-const ResultInfoBoxList: React.FC<ResultListProps> = ({
-  results,
-  setDetectedLines,
-}) => {
+const CodeResultsList = ({ results }: CodeResultsListProps) => {
   return (
     <div className="mt-10 flex flex-col gap-y-6">
       {Array.isArray(results) ? (
         // 취약점 검출 O
         <>
           {results.map((result, index) => (
-            <ResultInfoBox
-              key={index}
-              setLines={setDetectedLines}
-              {...result}
-            />
+            <CodeResultsListItem key={index} {...result} />
           ))}
         </>
       ) : (
@@ -40,4 +31,4 @@ const ResultInfoBoxList: React.FC<ResultListProps> = ({
   );
 };
 
-export default ResultInfoBoxList;
+export default CodeResultsList;

--- a/src/components/analyze/CodeResultsListItem.tsx
+++ b/src/components/analyze/CodeResultsListItem.tsx
@@ -1,3 +1,4 @@
+import { useFileViewerStore } from "@/stores/useFileViewerStore";
 import { FileResultProps } from "@/types/file";
 import {
   InfoBox,
@@ -9,22 +10,20 @@ import {
 } from "../ui/InfoBox";
 import { Label } from "../ui/Label";
 import CodeBlock from "./CodeBlock";
-import { Dispatch, SetStateAction } from "react";
 
-type ResultInfoBoxProps = FileResultProps & {
-  setLines: Dispatch<SetStateAction<number[]>>;
-};
-
-export default function ResultInfoBox({
+export default function CodeResultsListItem({
   name,
   vulnerability,
   descriptions,
   lines,
   modified_codes,
-  setLines,
-}: ResultInfoBoxProps) {
+}: FileResultProps) {
   const modifiedCodeStr = modified_codes?.join("\n") ?? "";
+  const setDetectedLines = useFileViewerStore(
+    (state) => state.setDetectedLines,
+  );
 
+  // lines 파싱
   let linesRange: number[] = [];
   if (lines.includes(",")) {
     const ranges = lines.split(",");
@@ -55,7 +54,7 @@ export default function ResultInfoBox({
         <Label
           variant="location"
           className="cursor-pointer border-accent-red text-accent-red"
-          onClick={() => setLines(linesRange)}
+          onClick={() => setDetectedLines(linesRange)}
         >
           위치보기
         </Label>

--- a/src/components/analyze/CodeViewer.tsx
+++ b/src/components/analyze/CodeViewer.tsx
@@ -105,7 +105,7 @@ export default function CodeViewer({
   return (
     <div
       className={cn(
-        "relative h-full w-full overflow-hidden overflow-x-scroll rounded-lg border border-[#c3c3c3]",
+        "relative h-full w-full overflow-hidden rounded-lg border border-[#c3c3c3]",
         className,
       )}
     >

--- a/src/components/analyze/CodeViewer.tsx
+++ b/src/components/analyze/CodeViewer.tsx
@@ -1,16 +1,11 @@
 "use client";
 
-import { getDetectedResultsByFile } from "@/lib/api/repositories";
 import { useFileContent } from "@/lib/queries/useFileContent";
 import { cn } from "@/lib/utils";
-import { useDetectedModeStore } from "@/stores/useDetectedModeStore";
-import { useFileProcessStore } from "@/stores/useFileProcessStore";
 import { useFileViewerStore } from "@/stores/useFileViewerStore";
 import dynamic from "next/dynamic";
 import { useEffect, useRef, useState } from "react";
-import { Alert } from "../ui/Alert";
 import { IconMagnifierWithPlus } from "../ui/Icons";
-import ResultInfoBoxList from "./ResultInfoBoxList";
 
 const SyntaxHighlighter = dynamic(
   () => import("react-syntax-highlighter").then((mod) => mod.Prism),
@@ -22,30 +17,23 @@ interface CodeViewerProps {
   repo: string;
 }
 
-export default function CodeViewer({ username, repo }: CodeViewerProps) {
+export default function CodeViewer({
+  username,
+  repo,
+  className,
+}: CodeViewerProps & React.HTMLAttributes<HTMLDivElement>) {
   const codeRef = useRef<HTMLPreElement>(null);
 
-  const mode = useDetectedModeStore((state) => state.mode);
-  const setMode = useDetectedModeStore((state) => state.setMode);
   const { currentFile, setCurrentFile, setCurrentRepo } = useFileViewerStore();
+  const detectedLines = useFileViewerStore((state) => state.detectedLines);
+
   const { data, isLoading, error } = useFileContent(
     username,
     repo,
     currentFile,
   );
-  const getFileStatus = useFileProcessStore((state) => state.getFileStatus);
-  const setFileStatus = useFileProcessStore((state) => state.setFileStatus);
-  const results = useFileProcessStore((state) => state.fileDetectedResults);
-  const setResults = useFileProcessStore(
-    (state) => state.setFileDetectedResults,
-  );
-  const filePath = useFileProcessStore((state) => state.currentDetectedFile);
-  const status = currentFile ? getFileStatus(currentFile) : null;
 
   const [highlighterStyle, setHighlighterStyle] = useState({});
-  const [hasAlertBeenSet, setHasAlertBeenSet] = useState(false);
-  const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const [detectedLines, setDetectedLines] = useState<number[]>([]);
 
   useEffect(() => {
     setCurrentFile(null);
@@ -57,37 +45,6 @@ export default function CodeViewer({ username, repo }: CodeViewerProps) {
       (mod) => setHighlighterStyle(mod.default),
     );
   }, []);
-
-  // 검사 결과가 있는 파일에 한해서 취약점 검사 결과 조회
-  useEffect(() => {
-    setMode("undetected");
-    setResults(null);
-
-    const getResults = async () => {
-      try {
-        const { mode, results } = await getDetectedResultsByFile(
-          username,
-          currentFile,
-        );
-        setMode(mode);
-        setResults(results);
-      } catch (err) {
-        console.error("Error fetching detected results:", err);
-      }
-    };
-
-    if (currentFile && status === "success") {
-      getResults();
-    }
-  }, [currentFile]);
-
-  // 검사 상태에 따른 Alert 출력
-  useEffect(() => {
-    if (currentFile === filePath && status) {
-      setIsAlertOpen(true);
-      setHasAlertBeenSet(true);
-    }
-  }, [status]);
 
   // 위치 보기 하이라이트
   useEffect(() => {
@@ -138,7 +95,7 @@ export default function CodeViewer({ username, repo }: CodeViewerProps) {
 
   if (!data && !isLoading && !error) {
     return (
-      <div className="flex-center-center w-full flex-col gap-8 rounded-lg border border-[#c3c3c3]">
+      <div className="flex-center-center size-full flex-col gap-8 rounded-lg border border-[#c3c3c3]">
         <IconMagnifierWithPlus />
         <div className="text-2xl text-primary-500">파일을 선택하세요</div>
       </div>
@@ -148,46 +105,29 @@ export default function CodeViewer({ username, repo }: CodeViewerProps) {
   return (
     <div
       className={cn(
-        "w-full overflow-x-scroll",
-        results && mode === "detected" && "min-h-dvh",
+        "relative h-full w-full overflow-hidden overflow-x-scroll rounded-lg border border-[#c3c3c3]",
+        className,
       )}
     >
-      {/* 코드 뷰어 */}
-      <div
-        className={cn(
-          "relative h-full w-full overflow-hidden rounded-lg border border-[#c3c3c3]",
-          results && mode === "detected" && "h-full max-h-[34.688rem]",
+      {/* <ProcessStatus status={status} /> */}
+      <SyntaxHighlighter
+        language={data?.type === "code" ? data.language : "text"}
+        style={highlighterStyle}
+        showLineNumbers
+        wrapLines
+        className="p-11"
+        PreTag={({ children, ...props }) => (
+          <pre
+            {...props}
+            className="!m-0 h-full w-full max-w-full !overflow-x-auto"
+            ref={codeRef}
+          >
+            {children}
+          </pre>
         )}
       >
-        {/* <ProcessStatus status={status} /> */}
-        <SyntaxHighlighter
-          language={data?.type === "code" ? data.language : "text"}
-          style={highlighterStyle}
-          showLineNumbers
-          wrapLines
-          className="p-11"
-          PreTag={({ children, ...props }) => (
-            <pre
-              {...props}
-              className="!m-0 h-full w-full max-w-full !overflow-x-auto"
-              ref={codeRef}
-            >
-              {children}
-            </pre>
-          )}
-        >
-          {renderContent()}
-        </SyntaxHighlighter>
-        {isAlertOpen && <Alert username={username} status={status} />}
-      </div>
-
-      {/* 검사 결과 */}
-      {results && mode === "detected" && (
-        <ResultInfoBoxList
-          results={results}
-          setDetectedLines={setDetectedLines}
-        />
-      )}
+        {renderContent()}
+      </SyntaxHighlighter>
     </div>
   );
 }

--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { getDetectedResultsByFile } from "@/lib/api/repositories";
 import { cn } from "@/lib/utils";
 import { useDetectedModeStore } from "@/stores/useDetectedModeStore";
+import { useFileProcessStore } from "@/stores/useFileProcessStore";
 import { useFileViewerStore } from "@/stores/useFileViewerStore";
-import { useState } from "react";
 import Button from "./Button";
 import {
   IconArrowsCounterClockwise,
@@ -12,8 +13,6 @@ import {
   IconHourGlass,
   IconThinClose,
 } from "./Icons";
-import { getDetectedResultsByFile } from "@/lib/api/repositories";
-import { useFileProcessStore } from "@/stores/useFileProcessStore";
 
 const alertType = {
   onCheck: {
@@ -70,15 +69,18 @@ type AlertProperty = {
 
 type AlertType = {
   status: keyof typeof alertType | null;
+  isOpen: boolean;
+  onClose: () => void;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 export const Alert = ({
   username,
   status = "onWait",
+  isOpen,
+  onClose,
   className,
   ...props
 }: { username: string } & AlertType) => {
-  const [isOpen, setIsOpen] = useState(true);
   const repoName = useFileViewerStore((state) => state.currentRepo);
   const filePath = useFileViewerStore((state) => state.currentFile);
   const setMode = useDetectedModeStore((state) => state.setMode);
@@ -96,69 +98,67 @@ export const Alert = ({
 
   const onClickToResults = async () => {
     try {
+      onClose();
+      
       const { mode, results } = await getDetectedResultsByFile(
         username,
         filePath,
       );
 
-      setMode(mode);
-      setResults(results);
-      window.history.replaceState({}, "", `/repos/${repoName}/${filePath}`);
-      setIsOpen(false);
+      if (filePath) {
+        setMode(filePath, mode);
+        setResults(results);
+        // window.history.replaceState({}, "", `/repos/${repoName}/${filePath}`);
+      }
     } catch (err) {
       console.error("Error fetching results:", err);
     }
   };
 
   return (
-    <>
-      {isOpen && (
-        <div
-          className={cn(
-            "absolute right-0 top-0 z-30 flex h-fit w-full max-w-[30.875rem] justify-between gap-x-[1.125rem] rounded-2xl bg-white p-8 shadow-[0_0.75rem_2.656rem_0_rgba(0,0,0,0.12)]",
-            className,
-          )}
-          {...props}
-        >
-          <div className="flex basis-12 justify-center">{icon}</div>
+    isOpen && (
+      <div
+        className={cn(
+          "absolute right-0 top-0 z-30 flex h-fit w-full max-w-[30.875rem] justify-between gap-x-[1.125rem] rounded-2xl bg-white p-8 shadow-[0_0.75rem_2.656rem_0_rgba(0,0,0,0.12)]",
+          className,
+        )}
+        {...props}
+      >
+        <div className="flex basis-12 justify-center">{icon}</div>
 
-          <div className="flex grow flex-col gap-y-4 text-xl font-medium leading-7">
-            <h4>{title}</h4>
-            <p className="flex flex-col text-[1.125rem] text-gray-default">
-              {descriptions.map((desc, index) => (
-                <span key={index}>{desc}</span>
-              ))}
-            </p>
-            {button &&
-              (status === "success" ? (
-                <Button
-                  variant="filled"
-                  shape="rounded"
-                  className="w-full rounded-[0.75rem] py-3 text-2xl font-medium leading-[2.1rem]"
-                  onClick={onClickToResults}
-                >
-                  {button.text}
-                </Button>
-              ) : (
-                <Button
-                  variant="filled"
-                  shape="rounded"
-                  className="w-full rounded-[0.75rem] py-3 text-2xl font-medium leading-[2.1rem]"
-                  onClick={button.action}
-                >
-                  {button.text}
-                </Button>
-              ))}
-          </div>
-
-          <div className="shrink-0 basis-8">
-            <IconThinClose
-              className="size-8 cursor-pointer"
-              onClick={() => setIsOpen(false)}
-            />
-          </div>
+        <div className="flex grow flex-col gap-y-4 text-xl font-medium leading-7">
+          <h4>{title}</h4>
+          <p className="flex flex-col text-[1.125rem] text-gray-default">
+            {descriptions.map((desc, index) => (
+              <span key={index}>{desc}</span>
+            ))}
+          </p>
+          {button &&
+            (status === "success" ? (
+              <Button
+                variant="filled"
+                shape="rounded"
+                className="w-full rounded-[0.75rem] py-3 text-2xl font-medium leading-[2.1rem]"
+                onClick={onClickToResults}
+              >
+                {button.text}
+              </Button>
+            ) : (
+              <Button
+                variant="filled"
+                shape="rounded"
+                className="w-full rounded-[0.75rem] py-3 text-2xl font-medium leading-[2.1rem]"
+                onClick={button.action}
+              >
+                {button.text}
+              </Button>
+            ))}
         </div>
-      )}
-    </>
+
+        <div className="shrink-0 basis-8">
+          <IconThinClose className="size-8 cursor-pointer" onClick={onClose} />
+        </div>
+      </div>
+    )
   );
 };

--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -81,7 +81,7 @@ export const Alert = ({
   className,
   ...props
 }: { username: string } & AlertType) => {
-  const repoName = useFileViewerStore((state) => state.currentRepo);
+  // const repoName = useFileViewerStore((state) => state.currentRepo);
   const filePath = useFileViewerStore((state) => state.currentFile);
   const setMode = useDetectedModeStore((state) => state.setMode);
   const setResults = useFileProcessStore(
@@ -99,7 +99,7 @@ export const Alert = ({
   const onClickToResults = async () => {
     try {
       onClose();
-      
+
       const { mode, results } = await getDetectedResultsByFile(
         username,
         filePath,

--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -38,9 +38,6 @@ const alertType = {
     descriptions: ["오류가 발생했습니다.", "다시 시도해주세요."],
     button: {
       text: "다시 검사하기",
-      action: () => {
-        console.log("검사 함수 호출");
-      },
     },
   },
   success: {
@@ -63,7 +60,6 @@ type AlertProperty = {
   descriptions: string[];
   button?: {
     text: string;
-    action?: () => void;
   };
 };
 
@@ -81,12 +77,18 @@ export const Alert = ({
   className,
   ...props
 }: { username: string } & AlertType) => {
-  // const repoName = useFileViewerStore((state) => state.currentRepo);
+  const repoName = useFileViewerStore((state) => state.currentRepo);
   const filePath = useFileViewerStore((state) => state.currentFile);
   const setMode = useDetectedModeStore((state) => state.setMode);
+  const processFile = useFileProcessStore((state) => state.processFile);
   const setResults = useFileProcessStore(
     (state) => state.setFileDetectedResults,
   );
+
+  const file = {
+    path: filePath ?? "",
+    name: filePath?.split("/").pop() ?? "",
+  };
 
   if (!status) {
     return null;
@@ -113,6 +115,10 @@ export const Alert = ({
     } catch (err) {
       console.error("Error fetching results:", err);
     }
+  };
+
+  const onClickToRetry = async () => {
+    await processFile(username, repoName, file);
   };
 
   return (
@@ -148,7 +154,7 @@ export const Alert = ({
                 variant="filled"
                 shape="rounded"
                 className="w-full rounded-[0.75rem] py-3 text-2xl font-medium leading-[2.1rem]"
-                onClick={button.action}
+                onClick={onClickToRetry}
               >
                 {button.text}
               </Button>

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -420,6 +420,6 @@ export const updateRepoStatus = async (
       throw new Error(errorData.error || "Failed to save results.");
     }
   } catch (err) {
-    console.error("Error adding results:", err);
+    console.error("Error occurs update results status:", err);
   }
 };

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -420,6 +420,6 @@ export const updateRepoStatus = async (
       throw new Error(errorData.error || "Failed to save results.");
     }
   } catch (err) {
-    console.error("Error occurs update results status:", err);
+    console.error("Error occurs updating results status:", err);
   }
 };

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -12,6 +12,7 @@ import {
 } from "firebase/firestore";
 import { User } from "next-auth";
 import db from "../../../firebaseConfig";
+import { FILE_INSPECTION_STATUS_KEY } from "../const";
 
 /**
  * Firestore에 새로운 user를 추가합니다.
@@ -134,6 +135,11 @@ export async function deleteUserData(username: string): Promise<void> {
     reposSnapshot.forEach(async (doc) => {
       await deleteDoc(doc.ref);
     });
+
+    // 4. 로컬 스토리지 안의 데이터 삭제
+    if (typeof window !== "undefined") {
+      localStorage.removeItem(FILE_INSPECTION_STATUS_KEY);
+    }
 
     console.log(`유저 ${username}의 모든 정보를 삭제했습니다.`);
   } catch (error) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -140,9 +140,18 @@ export const convertEscapedCharacterToRawString = (str: string) => {
   return str
     .replace(/\/([^\/]+)\/g/g, "\\\\/$1\\\\/g") // 정규식 문자열을 두 개의 백슬래시로 감싸기
     .replace(/'/g, `\\"`) // 싱글 쿼테이션
-    .replace(/\/"/g, `/\\"`) // 슬래쉬 + 더블 쿼테이션
     .replace(/</g, "\\u003C") // '<' 문자
     .replace(/>/g, "\\u003E"); // '>' 문자
+  // .replace(/\\/g, "\\\\") // 백슬래시 이스케이프 처리
+  // .replace(/\n/g, "\\n") // 줄바꿈 문자 이스케이프 처리
+  // .replace(/\r/g, "\\r") // 캐리지 리턴 문자 이스케이프 처리
+  // .replace(/\t/g, "\\t") // 탭 문자 이스케이프 처리
+  // .replace(/\\u([a-fA-F0-9]{4})/g, (match, p1) => {
+  //   // 유니코드 이스케이프 시퀀스 처리
+  //   return String.fromCharCode(parseInt(p1, 16));
+  // })
+  // .replace(/[\b]/g, "\\b") // JSON에서 특별한 의미를 가지는 제어 문자 이스케이프 처리
+  // .replace(/\f/g, "\\f");
 };
 
 // 분석 제외 파일 리스트

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -142,16 +142,6 @@ export const convertEscapedCharacterToRawString = (str: string) => {
     .replace(/'/g, `\\"`) // 싱글 쿼테이션
     .replace(/</g, "\\u003C") // '<' 문자
     .replace(/>/g, "\\u003E"); // '>' 문자
-  // .replace(/\\/g, "\\\\") // 백슬래시 이스케이프 처리
-  // .replace(/\n/g, "\\n") // 줄바꿈 문자 이스케이프 처리
-  // .replace(/\r/g, "\\r") // 캐리지 리턴 문자 이스케이프 처리
-  // .replace(/\t/g, "\\t") // 탭 문자 이스케이프 처리
-  // .replace(/\\u([a-fA-F0-9]{4})/g, (match, p1) => {
-  //   // 유니코드 이스케이프 시퀀스 처리
-  //   return String.fromCharCode(parseInt(p1, 16));
-  // })
-  // .replace(/[\b]/g, "\\b") // JSON에서 특별한 의미를 가지는 제어 문자 이스케이프 처리
-  // .replace(/\f/g, "\\f");
 };
 
 // 분석 제외 파일 리스트

--- a/src/stores/useDetectedModeStore.ts
+++ b/src/stores/useDetectedModeStore.ts
@@ -3,11 +3,18 @@ import { create } from "zustand";
 export type Mode = "undetected" | "detected";
 
 type DetectedModeStore = {
-  mode: Mode;
-  setMode: (mode: Mode) => void;
+  modes: { [filePath: string]: Mode };
+  setMode: (filePath: string, mode: Mode) => void;
+  getMode: (filePath: string) => Mode;
 };
 
-export const useDetectedModeStore = create<DetectedModeStore>((set) => ({
-  mode: "undetected",
-  setMode: (mode: Mode) => set({ mode }),
+export const useDetectedModeStore = create<DetectedModeStore>((set, get) => ({
+  modes: {},
+  setMode: (filePath: string, mode: Mode) =>
+    set((state) => ({
+      modes: { ...state.modes, [filePath]: mode },
+    })),
+  getMode: (filePath: string) => {
+    return get().modes[filePath] || "undetected";
+  },
 }));

--- a/src/stores/useFileProcessStore.ts
+++ b/src/stores/useFileProcessStore.ts
@@ -10,7 +10,7 @@ import { v4 as uuidv4 } from "uuid";
 import { create } from "zustand";
 import { FILE_INSPECTION_STATUS_KEY } from "../lib/const";
 
-// 파일 검사 여부 -> 로컬 스토리지에 저장
+// 파일 검사 여부 있는 경우, 로컬 스토리지에 저장
 const saveFileStatusesToLocalStorage = (
   fileStatuses: Map<string, FileStatus>,
 ) => {
@@ -38,7 +38,7 @@ interface FileProcessState {
   fileDetectedResults: FileResultProps[] | FileResultFailProps | null;
   isInspectionRunning: boolean;
   setFileStatus: (path: string, status: FileStatus) => void;
-  getFileStatus: (path: string) => FileStatus;
+  getFileStatus: (path: string) => FileStatus | null;
   resetFileStatuses: () => void;
   setCurrentDetectedFile: (path: string | null) => void;
   setFileDetectedResults: (results: FileResultProps[] | null) => void;
@@ -73,31 +73,45 @@ export const useFileProcessStore = create<FileProcessState>((set, get) => ({
   processFiles: async (files, username, repo, action) => {
     const processFile = async (file: { path: string; name: string }) => {
       try {
+        // 파일 검사 상태 초기화
+        get().setFileDetectedResults(null);
         get().setFileStatus(file.path, "onCheck");
         const content = await fetchCodes(username, repo, file.path);
 
         // LLM 분석 수행
         const res = await generateLlm("analyze", content);
-        console.log("res", res);
         // 파싱 가능한 문자열로 변환 (JSON)
         const jsonStr = convertEscapedCharacterToRawString(res);
-        console.log("jsonStr", jsonStr);
-        // 파싱
-        const data = JSON.parse(jsonStr);
-        const results: FileResultProps[] = data.map(
-          (result: FileResultProps) => ({
-            ...result,
-            id: uuidv4(),
-          }),
-        );
-        // 결과 대상 파일 저장
-        get().setCurrentDetectedFile(file.path);
-        // 결과 저장
-        get().setFileDetectedResults(results);
-        // 결과 DB에 저장
-        await addFileResults(username, repo, file.path, results);
+        try {
+          // 파싱
+          const data = JSON.parse(jsonStr);
+
+          const results: FileResultProps[] = data.map(
+            (result: FileResultProps) => ({
+              ...result,
+              id: uuidv4(),
+            }),
+          );
+
+          // 결과 대상 파일 저장
+          get().setCurrentDetectedFile(file.path);
+
+          // 결과 저장
+          get().setFileDetectedResults(results);
+          try {
+            // 결과 DB에 저장
+            await addFileResults(username, repo, file.path, results);
+          } catch (err) {
+            get().setFileStatus(file.path, "error");
+          }
+        } catch (error) {
+          console.error(`Error parsing JSON:`, error);
+          get().setFileStatus(file.path, "error");
+        }
+
         // 파일 검사 상태 변경
         get().setFileStatus(file.path, "success");
+        
         // 파일 검사 상태 저장
         await updateRepoStatus(username, repo, "onProgress");
       } catch (error) {

--- a/src/stores/useFileProcessStore.ts
+++ b/src/stores/useFileProcessStore.ts
@@ -112,7 +112,7 @@ export const useFileProcessStore = create<FileProcessState>((set, get) => ({
 
         try {
           // 파일 검사 상태 저장
-          await updateRepoStatus(username, repo, "done");
+          await updateRepoStatus(username, repo, "onProgress");
         } catch (err) {
           console.error(`Error updating repo status:`, err);
           get().setFileStatus(file.path, "error");

--- a/src/stores/useFileProcessStore.ts
+++ b/src/stores/useFileProcessStore.ts
@@ -43,6 +43,11 @@ interface FileProcessState {
   setCurrentDetectedFile: (path: string | null) => void;
   setFileDetectedResults: (results: FileResultProps[] | null) => void;
   setIsInspectionRunning: (isRunning: boolean) => void;
+  processFile: (
+    username: string,
+    repo: string,
+    file: { path: string; name: string },
+  ) => Promise<void>;
   processFiles: (
     files: Array<{ path: string; name: string }>,
     username: string,
@@ -70,65 +75,68 @@ export const useFileProcessStore = create<FileProcessState>((set, get) => ({
   setFileDetectedResults: (results) => set({ fileDetectedResults: results }),
   setIsInspectionRunning: (isRunning: boolean) =>
     set({ isInspectionRunning: isRunning }),
-  processFiles: async (files, username, repo, action) => {
-    const processFile = async (file: { path: string; name: string }) => {
+  processFile: async (username, repo, file: { path: string; name: string }) => {
+    try {
+      // 파일 검사 상태 초기화
+      get().setFileDetectedResults(null);
+      get().setFileStatus(file.path, "onCheck");
+      const content = await fetchCodes(username, repo, file.path);
+
       try {
-        // 파일 검사 상태 초기화
-        get().setFileDetectedResults(null);
-        get().setFileStatus(file.path, "onCheck");
-        const content = await fetchCodes(username, repo, file.path);
+        // LLM 분석 수행
+        const res = await generateLlm("analyze", content);
+        // 파싱 가능한 문자열로 변환 (JSON)
+        const jsonStr = convertEscapedCharacterToRawString(res);
+        // 파싱
+        const data = await JSON.parse(jsonStr);
+
+        const results: FileResultProps[] = data.map(
+          (result: FileResultProps) => ({
+            ...result,
+            id: uuidv4(),
+          }),
+        );
+
+        // 결과 대상 파일 저장
+        get().setCurrentDetectedFile(file.path);
+
+        // 결과 저장
+        get().setFileDetectedResults(results);
 
         try {
-          // LLM 분석 수행
-          const res = await generateLlm("analyze", content);
-          // 파싱 가능한 문자열로 변환 (JSON)
-          const jsonStr = convertEscapedCharacterToRawString(res);
-          // 파싱
-          const data = await JSON.parse(jsonStr);
-
-          const results: FileResultProps[] = data.map(
-            (result: FileResultProps) => ({
-              ...result,
-              id: uuidv4(),
-            }),
-          );
-
-          // 결과 대상 파일 저장
-          get().setCurrentDetectedFile(file.path);
-
-          // 결과 저장
-          get().setFileDetectedResults(results);
-
-          try {
-            // 결과 DB에 저장
-            await addFileResults(username, repo, file.path, results);
-          } catch (err) {
-            get().setFileStatus(file.path, "error");
-          }
-        } catch (error) {
-          console.error(`Error parsing JSON:`, error);
-          get().setFileStatus(file.path, "error");
-        }
-
-        try {
-          // 파일 검사 상태 저장
-          await updateRepoStatus(username, repo, "onProgress");
+          // 결과 DB에 저장
+          await addFileResults(username, repo, file.path, results);
         } catch (err) {
-          console.error(`Error updating repo status:`, err);
           get().setFileStatus(file.path, "error");
+          return;
         }
-
-        // 파일 검사 상태 변경
-        get().setFileStatus(file.path, "success");
       } catch (error) {
+        console.error(`Error parsing JSON:`, error);
         get().setFileStatus(file.path, "error");
-        console.error(`Error processing file ${file.name}:`, error);
+        return;
       }
-    };
 
+      try {
+        // 파일 검사 상태 DB에 저장
+        await updateRepoStatus(username, repo, "onProgress");
+      } catch (err) {
+        console.error(`Error updating repo status:`, err);
+        get().setFileStatus(file.path, "error");
+        return;
+      }
+
+      // 파일 검사 상태 변경
+      get().setFileStatus(file.path, "success");
+    } catch (error) {
+      get().setFileStatus(file.path, "error");
+      console.error(`Error processing file ${file.name}:`, error);
+      return;
+    }
+  },
+  processFiles: async (files, username, repo, action) => {
     // 파일을 순차적으로 처리
     for (const file of files) {
-      await processFile(file);
+      await get().processFile(username, repo, file);
     }
     set({ isInspectionRunning: false });
   },

--- a/src/stores/useFileViewerStore.ts
+++ b/src/stores/useFileViewerStore.ts
@@ -2,15 +2,19 @@ import { create } from "zustand";
 interface FileViewerState {
   currentFile: string | null;
   currentRepo: string;
+  detectedLines: number[]; // 취약점 검사 결과에서 위치 보기 버튼 클릭 시 해당되는 코드 라인
   setCurrentFile: (file: string | null) => void;
   setCurrentRepo: (repo: string) => void;
   resetFileViewer: () => void;
+  setDetectedLines: (lines: number[]) => void;
 }
 
 export const useFileViewerStore = create<FileViewerState>((set) => ({
   currentFile: null,
   currentRepo: "",
+  detectedLines: [],
   setCurrentFile: (file) => set({ currentFile: file }),
   setCurrentRepo: (repo) => set({ currentRepo: repo }),
   resetFileViewer: () => set({ currentFile: null, currentRepo: "" }),
+  setDetectedLines: (lines: number[]) => set({ detectedLines: lines }),
 }));


### PR DESCRIPTION
## 변경사항 및 이유
- 검사 상태에 따른 Alert 출력 버그 발생
- 검사 성공된 결과에 대한 출력 버그 발생
- 로그아웃 시, 로컬 스토리지에 저장되어 있는 `파일 검사 상태 여부(FileStatuses)` 삭제 처리

## 작업 내역
- CodeViewer 컴포넌트 분리 작업
  - 상위 컴포넌트 CodeContainer를 생성하여 그 안에서 `코드 뷰어`와 `검사 결과`를 따로 처리하도록 바꾸었습니다.
    - 상위 컴포넌트가 달라짐에 따라, `app/repos/page.tsx` 에서는 CodeContainer를 불러오게끔 바꾸었습니다.
  - CodeViewer 컴포넌트는 `위치 보기` 버튼에 대한 처리만 남겨두고, Alert 출력과 검사 결과 출력 기능은 분리하였습니다.
    - 조건부 스타일링 설정이 필요하여 기존 props에 `className`을 추가하였습니다.
- Alert 출력 버그 이슈 해결
- 검사 결과 출력 버그 이슈 해결
  - 두 이슈 모두 리렌더링 감지와 그에 따른 조건을 잘못 주어 발생하여 이를 바로잡았습니다.
- useFileViewerStore.ts에 detectedLines와 setDetectedLines 속성을 추가했습니다. (취약점 발견 코드 라인)
- useFileProcessStore.ts processFiles 메서드에 예외 처리 (try catch 문) 추가했습니다.

## PR 특이 사항
- [x] 빌드 통과했습니다!