### PR TITLE
Modify: 취약점 분석 검사 응답 파싱 확장자 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "firebase": "^10.13.0",
+    "json5": "^2.2.3",
     "next": "14.2.5",
     "next-auth": "5.0.0-beta.20",
     "nodemailer": "^6.9.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       firebase:
         specifier: ^10.13.0
         version: 10.13.0
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
       next:
         specifier: 14.2.5
         version: 14.2.5(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2418,6 +2421,11 @@ packages:
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
     hasBin: true
 
   jsonfile@6.1.0:
@@ -6992,6 +7000,8 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  json5@2.2.3: {}
 
   jsonfile@6.1.0:
     dependencies:

--- a/src/stores/useFileProcessStore.ts
+++ b/src/stores/useFileProcessStore.ts
@@ -9,6 +9,7 @@ import { FileResultFailProps, FileResultProps, FileStatus } from "@/types/file";
 import { v4 as uuidv4 } from "uuid";
 import { create } from "zustand";
 import { FILE_INSPECTION_STATUS_KEY } from "../lib/const";
+import JSON5 from "json5";
 
 // 파일 검사 여부 있는 경우, 로컬 스토리지에 저장
 const saveFileStatusesToLocalStorage = (
@@ -88,7 +89,7 @@ export const useFileProcessStore = create<FileProcessState>((set, get) => ({
         // 파싱 가능한 문자열로 변환 (JSON)
         const jsonStr = convertEscapedCharacterToRawString(res);
         // 파싱
-        const data = await JSON.parse(jsonStr);
+        const data = await JSON5.parse(jsonStr);
 
         const results: FileResultProps[] = data.map(
           (result: FileResultProps) => ({


### PR DESCRIPTION
## 변경사항 및 이유
- JSON의 엄격한 Syntax 규칙을 준수하기 위해 일일이 문자를 이스케이프해줘야 하는 문제 상황 발생

## 작업 내역
- JSON 대신 JSON5를 적용하여 JSON의 Syntax 규칙 완화 (👍정아님👍이 추천해주신 모듈)

## PR 특이 사항
- [x] 빌드 테스트 통과했습니다!