### PR TITLE
Feat : 고객센터 문의하기 폼 유효성 검사 안내 메세지 추가

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -13,12 +13,10 @@ export async function POST(request: NextRequest) {
   const email = formData.get("email");
   const message = formData.get("message");
 
-  const namePattern = /^[a-zA-Z가-힣]+$/;
   const emailPattern = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
   if (
     typeof name !== "string" ||
-    !namePattern.test(name.trim()) ||
     name.includes(" ") ||
     name.trim().length < 2
   ) {

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,3 +1,9 @@
+import {
+  EMAIL_VALIDATION_MESSAGE,
+  MESSAGE_VALIDATION_MESSAGE,
+  NAME_VALIDATION_MESSAGE,
+  SERVER_ERROR_MESSAGE,
+} from "@/lib/const";
 import { sendEmail } from "@/lib/contact";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -7,28 +13,42 @@ export async function POST(request: NextRequest) {
   const email = formData.get("email");
   const message = formData.get("message");
 
-  // 유효성 검사 (name: 2자 이상, email: email형식, message: 5자 이상)
-  if (typeof name !== "string" || name.length < 2) {
-    return NextResponse.json({ message: "INVALID NAME", status: 400 });
-  }
-
+  const namePattern = /^[a-zA-Z가-힣]+$/;
   const emailPattern = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
-  if (typeof email !== "string" || !emailPattern.test(email)) {
-    return NextResponse.json({ message: "INVALID EMAIL", status: 400 });
+
+  if (
+    typeof name !== "string" ||
+    !namePattern.test(name.trim()) ||
+    name.includes(" ") ||
+    name.trim().length < 2
+  ) {
+    return NextResponse.json({
+      message: NAME_VALIDATION_MESSAGE,
+      status: 400,
+    });
   }
 
-  if (typeof message !== "string" || message.length < 5) {
-    return NextResponse.json({ message: "INVALID MESSAGE", status: 400 });
+  if (typeof email !== "string" || !emailPattern.test(email.trim())) {
+    return NextResponse.json({
+      message: EMAIL_VALIDATION_MESSAGE,
+      status: 400,
+    });
+  }
+
+  if (typeof message !== "string" || message.trim().length < 5) {
+    return NextResponse.json({
+      message: MESSAGE_VALIDATION_MESSAGE,
+      status: 400,
+    });
   }
 
   try {
-    await sendEmail(name as string, email as string, message as string);
-
+    await sendEmail(name.trim(), email.trim(), message.trim());
     return NextResponse.json({ message: "SUCCESS", status: 200 });
   } catch (error) {
     console.error("Error sending email:", error);
     return NextResponse.json({
-      message: "FAILED TO SEND MESSAGE",
+      message: SERVER_ERROR_MESSAGE,
       status: 500,
     });
   }

--- a/src/components/me/ContactForm.tsx
+++ b/src/components/me/ContactForm.tsx
@@ -39,7 +39,7 @@ function ValidationError({
   }
 
   return (
-    <p className="text-lg font-semibold text-red-500">
+    <p className="mt-1 text-lg font-semibold text-red-500">
       {validationMessages[invalidField]}
     </p>
   );
@@ -166,11 +166,11 @@ export default function ContactForm() {
     <form
       onSubmit={onSubmitForm}
       className={cn(
-        "flex h-full w-[61.563rem] flex-col gap-8 rounded-[2.5rem] border border-primary-500 bg-white p-[3.75rem]",
+        "flex h-full w-[61.563rem] flex-col gap-8 rounded-[2.5rem] border border-primary-500 bg-white px-[3.75rem] py-12",
       )}
     >
       <div>
-        <h3 className="mb-6 text-2xl font-bold leading-9">문의하기</h3>
+        <h3 className="mb-4 text-2xl font-bold leading-9">문의하기</h3>
         <p className="text-base font-medium tracking-[-0.011em] text-[#8F8F8F]">
           문의하고싶은 내용을 구체적으로 작성해주셔야 피드백이 정상적으로
           반영됩니다.
@@ -234,18 +234,19 @@ export default function ContactForm() {
           <ValidationError invalidField="message" />
         )}
       </div>
+      <div>
+        {/* Message for SERVER ERROR */}
+        {requestState === "error" && (
+          <p className="mb-2 text-lg font-semibold text-red-500">
+            {SERVER_ERROR_MESSAGE}
+          </p>
+        )}
 
-      {/* Message for SERVER ERROR */}
-      {requestState === "error" && (
-        <p className="text-lg font-semibold text-red-500">
-          {SERVER_ERROR_MESSAGE}
-        </p>
-      )}
-
-      {/* Button for SUBMIT */}
-      <Button type="submit" className="py-[0.813rem] text-lg">
-        {requestState === "loading" ? "전송 중..." : "문의 보내기"}
-      </Button>
+        {/* Button for SUBMIT */}
+        <Button type="submit" className="w-full py-[0.813rem] text-lg">
+          {requestState === "loading" ? "전송 중..." : "문의 보내기"}
+        </Button>
+      </div>
 
       {/* Modal for SUCCESS */}
       <ContactSuccessModal

--- a/src/components/me/ContactForm.tsx
+++ b/src/components/me/ContactForm.tsx
@@ -23,11 +23,11 @@ import {
 type RequestState = "idle" | "loading" | "success" | "error";
 type InvalidField = "name" | "email" | "message";
 
-const ValidationError = ({
+function ValidationError({
   invalidField,
 }: {
   invalidField: InvalidField | null;
-}) => {
+}) {
   const validationMessages: { [key in InvalidField]: string } = {
     name: NAME_VALIDATION_MESSAGE,
     email: EMAIL_VALIDATION_MESSAGE,
@@ -43,11 +43,48 @@ const ValidationError = ({
       {validationMessages[invalidField]}
     </p>
   );
-};
+}
+
+function ContactSuccessModal({
+  requestState,
+  setRequestState,
+}: {
+  requestState: RequestState;
+  setRequestState: React.Dispatch<React.SetStateAction<RequestState>>;
+}) {
+  const router = useRouter();
+
+  return (
+    <Modal
+      variant="inquirySubmitted"
+      size="extraLarge"
+      isOpen={requestState === "success"}
+      className="top-0 border border-primary-500"
+    >
+      <ModalTitleWrapper variant="inquirySubmitted">
+        <ModalTitle size="big" weight="bold">
+          문의를 보냈어요!
+        </ModalTitle>
+        <ModalDescription size="big" className="font-medium text-[#8F8F8F]">
+          문의를 성공적으로 전송했어요. 빠른 시일 내에 답변해드릴게요.
+        </ModalDescription>
+      </ModalTitleWrapper>
+      <Button
+        type="button"
+        onClick={() => {
+          setRequestState("idle");
+          router.push("/");
+        }}
+        className="mt-14 h-14 w-[20.938rem] rounded-2xl text-[1.25rem] tracking-[-0.011em]"
+      >
+        홈으로 가기
+      </Button>
+    </Modal>
+  );
+}
 
 export default function ContactForm() {
   const { data: session } = useSession();
-  const router = useRouter();
   const [invalidField, setInvalidField] = useState<InvalidField | null>(null);
   const [requestState, setRequestState] = useState<RequestState>("idle");
 
@@ -211,31 +248,10 @@ export default function ContactForm() {
       </Button>
 
       {/* Modal for SUCCESS */}
-      <Modal
-        variant="inquirySubmitted"
-        size="extraLarge"
-        isOpen={requestState === "success"}
-        className="top-0 border border-primary-500"
-      >
-        <ModalTitleWrapper variant="inquirySubmitted">
-          <ModalTitle size="big" weight="bold">
-            문의를 보냈어요!
-          </ModalTitle>
-          <ModalDescription size="big" className="font-medium text-[#8F8F8F]">
-            문의를 성공적으로 전송했어요. 빠른 시일 내에 답변해드릴게요.
-          </ModalDescription>
-        </ModalTitleWrapper>
-        <Button
-          type="button"
-          onClick={() => {
-            setRequestState("idle");
-            router.push("/");
-          }}
-          className="mt-14 h-14 w-[20.938rem] rounded-2xl text-[1.25rem] tracking-[-0.011em]"
-        >
-          홈으로 가기
-        </Button>
-      </Modal>
+      <ContactSuccessModal
+        requestState={requestState}
+        setRequestState={setRequestState}
+      />
     </form>
   );
 }

--- a/src/components/ui/CustomerService.tsx
+++ b/src/components/ui/CustomerService.tsx
@@ -12,7 +12,7 @@ export default function CustomerService({ className }: { className?: string }) {
     >
       <div className="h-full w-[28.125rem]">
         <h2 className="text-6xl font-bold leading-[5.625rem] tracking-tighter text-primary-500">
-          서비스이용에
+          서비스 이용에
           <br />
           문제가 생겼나요?
         </h2>

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -30,7 +30,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         type={type}
         onBlur={onBlurInput}
         className={cn(
-          "h-[51px] w-full rounded-lg border p-3 text-lg font-medium text-gray-dark outline-none placeholder:font-medium disabled:cursor-not-allowed disabled:bg-bggray-light",
+          "h-[51px] w-full rounded-lg border p-3 text-lg font-medium text-gray-dark outline-none placeholder:font-medium placeholder:text-gray-light disabled:cursor-not-allowed disabled:bg-bggray-light",
           className,
           isValid
             ? "bg-purple-light focus:bg-transparent"
@@ -38,8 +38,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
               ? "bg-red-light"
               : "bg-transparent focus:bg-transparent",
           isErrored
-            ? "border-accent-red placeholder:text-accent-red"
-            : "border-line-default placeholder:text-gray-light focus:border-primary-500",
+            ? "border-accent-red"
+            : "border-line-default focus:border-primary-500",
         )}
         ref={ref}
         {...props}

--- a/src/components/ui/TextArea.tsx
+++ b/src/components/ui/TextArea.tsx
@@ -30,7 +30,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
       <textarea
         onBlur={onBlurTextArea}
         className={cn(
-          "h-[220px] w-full resize-none rounded-lg border p-3 text-lg font-medium text-gray-dark outline-none placeholder:font-medium disabled:cursor-not-allowed disabled:bg-bggray-light",
+          "h-[220px] w-full resize-none rounded-lg border p-3 text-lg font-medium text-gray-dark outline-none placeholder:font-medium placeholder:text-gray-light disabled:cursor-not-allowed disabled:bg-bggray-light",
           className,
           isValid
             ? "bg-purple-light focus:bg-transparent"
@@ -38,8 +38,8 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
               ? "bg-red-light"
               : "bg-transparent focus:bg-transparent",
           isErrored
-            ? "border-accent-red placeholder:text-accent-red"
-            : "border-line-default placeholder:text-gray-light focus:border-primary-500",
+            ? "border-accent-red"
+            : "border-line-default focus:border-primary-500",
         )}
         ref={ref}
         {...props}

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -33,7 +33,7 @@ export const ITEMS_PER_MY_PAGE = 12;
 export const PAGES_PER_GROUP = 10;
 
 export const NAME_VALIDATION_MESSAGE =
-  "이름은 공백 없이 한글 또는 영어로 2자 이상이어야 합니다.";
+  "이름은 공백 없이 2자 이상이어야 합니다.";
 export const EMAIL_VALIDATION_MESSAGE = "이메일 형식이 유효하지 않습니다.";
 export const MESSAGE_VALIDATION_MESSAGE = "메세지는 5자 이상이어야 합니다.";
 export const SERVER_ERROR_MESSAGE =

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -32,6 +32,13 @@ export const ITEMS_PER_DB_PAGE = 5;
 export const ITEMS_PER_MY_PAGE = 12;
 export const PAGES_PER_GROUP = 10;
 
+export const NAME_VALIDATION_MESSAGE =
+  "이름은 공백 없이 한글 또는 영어로 2자 이상이어야 합니다.";
+export const EMAIL_VALIDATION_MESSAGE = "이메일 형식이 유효하지 않습니다.";
+export const MESSAGE_VALIDATION_MESSAGE = "메세지는 5자 이상이어야 합니다.";
+export const SERVER_ERROR_MESSAGE =
+  "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.";
+
 export const WEB_CRAWLING_SEARCH_KEYWORD = "vulnerability";
 
 export const WEB_CRAWLING_CERT_CC_API_URL = `${BASE_URL}/api/web-crawling/cert-cc`;


### PR DESCRIPTION
## 변경사항 및 이유
+ 고객센터 문의하기 폼에 유효성 검사 안내 메세지 추가했습니다.

## 작업 내역
+ 이름, 이메일, 메세지 필드 아래에 각각 해당 안내 메세지가 출력됩니다.
+ 사용자의 부담감을 줄이기 위해 오류 메세지를 한 번에 모두 띄우지 않고 순서대로 표시했습니다.



## PR 특이 사항
- [x] 빌드 테스트 통과했습니다!
![녹음-2024-09-21-191613](https://github.com/user-attachments/assets/79ac7ae4-1540-40ab-94d2-415d12fdde84)




