### PR TITLE
Design : Header ui 디자인 개선

### DIFF
--- a/src/components/landing/LandingDemoSection.tsx
+++ b/src/components/landing/LandingDemoSection.tsx
@@ -15,7 +15,7 @@ export default function LandingDemoSection() {
             <Button
               variant="filled"
               shape="rounded"
-              className="absolute top-[15.7%] z-50 translate-x-[42%] whitespace-nowrap bg-primary-300 px-[0.625rem] py-2 font-normal shadow-[0_1.5rem_2.25rem_0_rgba(0,0,0,0.25)]"
+              className="absolute top-[15.7%] z-40 translate-x-[42%] whitespace-nowrap bg-primary-300 px-[0.625rem] py-2 font-normal shadow-[0_1.5rem_2.25rem_0_rgba(0,0,0,0.25)]"
             >
               SectionBusinessForever from
               "@/components/section-business-forever";
@@ -23,14 +23,14 @@ export default function LandingDemoSection() {
             <Button
               variant="filled"
               shape="rounded"
-              className="absolute top-[29%] z-50 translate-x-[56.5%] bg-primary-300 px-[0.625rem] py-2 font-normal shadow-[0_1.5rem_2.25rem_0_rgba(0,0,0,0.25)]"
+              className="absolute top-[29%] z-40 translate-x-[56.5%] bg-primary-300 px-[0.625rem] py-2 font-normal shadow-[0_1.5rem_2.25rem_0_rgba(0,0,0,0.25)]"
             >
               "flex flex-col items-center py-36 min-h-screen"
             </Button>
             <Button
               variant="filled"
               shape="rounded"
-              className="absolute bottom-[27.4%] z-50 translate-x-[27%] bg-primary-300 px-[0.625rem] py-2 font-normal shadow-[0_1.5rem_2.25rem_0_rgba(0,0,0,0.25)]"
+              className="absolute bottom-[27.4%] z-40 translate-x-[27%] bg-primary-300 px-[0.625rem] py-2 font-normal shadow-[0_1.5rem_2.25rem_0_rgba(0,0,0,0.25)]"
             >
               Card className
             </Button>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -50,9 +50,10 @@ export default function Header() {
   return (
     <header
       className={cn(
-        "h-[8.5rem] w-full antialiased",
-        isDocsPage &&
-          "fixed top-0 z-20 w-full border-b border-white bg-transparent text-white backdrop-blur-md",
+        "top-0 z-50 h-[8.5rem] w-full antialiased",
+        isDocsPage
+          ? "fixed border-b border-white bg-transparent text-white backdrop-blur-md"
+          : "sticky bg-white",
       )}
     >
       <div className="flex-center-center mx-auto h-full max-w-[120rem] px-20 py-12">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -9,53 +9,56 @@ import { usePathname } from "next/navigation";
 // Logo Font
 const aldrich = Aldrich({ subsets: ["latin"], weight: "400" });
 
+function HeaderLogo({ isDocsPage }: { isDocsPage: boolean }) {
+  return (
+    <Link href={"/"} className="flex-center-center mr-[6.25rem]">
+      <IconBug
+        color={isDocsPage ? "text-white" : "text-primary-500"}
+        className={cn("mr-3 h-[35px] w-[34px]", isDocsPage && "text-white")}
+      />
+      <span className={`${aldrich.className} text-[2.5rem] tracking-[-0.01em]`}>
+        FLAWDETECTOR
+      </span>
+    </Link>
+  );
+}
+
+function NavMenu({ isDocsPage }: { isDocsPage: boolean }) {
+  return (
+    <nav className="w-full">
+      <ul
+        className={cn(
+          "flex-end-center w-full space-x-20 text-xl font-medium",
+          isDocsPage ? "text-white" : "text-gray-dark",
+        )}
+      >
+        <li>
+          <Link href={"/vuldb/items"}>취약점 DB</Link>
+        </li>
+        <li>
+          <Link href={"/repos"}>MY 저장소</Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}
+
 export default function Header() {
   const pathName = usePathname();
   const isDocsPage = pathName === "/ppa" || pathName === "/agreements";
 
   return (
-    <>
-      <header
-        className={cn(
-          "h-[8.5rem] w-full antialiased",
-          isDocsPage &&
-            "fixed top-0 z-20 w-full border-b border-white bg-transparent text-white backdrop-blur-md",
-        )}
-      >
-        <div className="flex-center-center mx-auto h-full max-w-[120rem] py-12 pl-20 pr-[3.563rem]">
-          {/* Logo */}
-          <Link href={"/"} className="flex-center-center mr-[6.25rem]">
-            <IconBug
-              color={isDocsPage ? "text-white" : "text-primary-500"}
-              className={cn(
-                "mr-3 h-[35px] w-[34px]",
-                isDocsPage && "text-white",
-              )}
-            />
-            <span
-              className={`${aldrich.className} text-[2.5rem] tracking-[-0.01em]`}
-            >
-              FLAWDETECTOR
-            </span>
-          </Link>
-          {/* Navigation */}
-          <nav className="w-full">
-            <ul
-              className={cn(
-                "flex-between-center w-full text-xl font-medium",
-                isDocsPage ? "text-white" : "text-gray-dark",
-              )}
-            >
-              <li>
-                <Link href={"/vuldb/items"}>취약점 DB</Link>
-              </li>
-              <li>
-                <Link href={"/repos"}>MY 저장소</Link>
-              </li>
-            </ul>
-          </nav>
-        </div>
-      </header>
-    </>
+    <header
+      className={cn(
+        "h-[8.5rem] w-full antialiased",
+        isDocsPage &&
+          "fixed top-0 z-20 w-full border-b border-white bg-transparent text-white backdrop-blur-md",
+      )}
+    >
+      <div className="flex-center-center mx-auto h-full max-w-[120rem] px-20 py-12">
+        <HeaderLogo isDocsPage={isDocsPage} />
+        <NavMenu isDocsPage={isDocsPage} />
+      </div>
+    </header>
   );
 }


### PR DESCRIPTION
## 변경사항 및 이유
+ Header ui 디자인 개선했습니다.

## 작업 내역
+ 양쪽으로 떨어져 있던 nav menu `취약점 DB`, `MY 저장소`를 Header 우측에 같이 두었고, 둘의 간격은 Header의 padding에 맞추었습니다.
+ 스크롤을 내려도 화면 상단에 Header가 고정됩니다.


## PR 특이 사항
- [x] 빌드 테스트 통과했습니다!
![화면 캡처 2024-09-21 205405](https://github.com/user-attachments/assets/2bde3f0c-9962-48dd-8bfa-1d7c67462e56)

<br/>

![화면 캡처 2024-09-21 205341](https://github.com/user-attachments/assets/6ab57e51-ee53-4390-b356-ae47161b3c7d)

